### PR TITLE
fix: /m3u 订阅接口改用 text/plain，修复飞牛(fnOS)无法订阅

### DIFF
--- a/app.js
+++ b/app.js
@@ -474,6 +474,8 @@ const server = http.createServer(async (req, res) => {
     }
     // 设置响应头
     res.setHeader('Content-Type', interfaceObj.contentType);
+    // 禁止客户端按内容嗅探覆盖声明的类型，确保飞牛/浏览器严格按 text/plain 当文本处理（与 GitHub raw 一致）
+    res.setHeader('X-Content-Type-Options', 'nosniff');
     if (routeUrlPath == "/m3u" || routeUrlPath == "/interface.m3u") {
       res.setHeader('content-disposition', "inline; filename=\"interface.m3u\"");
     }

--- a/utils/appUtils.js
+++ b/utils/appUtils.js
@@ -27,7 +27,12 @@ function interfaceStr(url, headers, urlUserId, urlToken, profile) {
 
     case "/m3u":
     case "/interface.m3u":
-      result.contentType = "audio/x-mpegurl; charset=utf-8"
+      // 必须用 text/plain，不能用 audio/x-mpegurl。
+      // audio/x-mpegurl 是“可播放的 HLS 媒体”类型，浏览器和飞牛(fnOS)订阅会把它当成一个视频去播放，
+      // 而不是当成订阅文本去解析，导致飞牛无法订阅、浏览器直接弹出播放器。
+      // GitHub raw 提供的 .m3u 就是 text/plain，飞牛能正常订阅——这里与之对齐。
+      // 普通播放器按正文(#EXTM3U)解析、忽略 Content-Type，所以改成 text/plain 对它们零影响。
+      result.contentType = "text/plain;charset=UTF-8"
       break;
 
     default:


### PR DESCRIPTION
## 问题
飞牛(fnOS)订阅自建源时，`.m3u` 被识别成视频，导致无法订阅。

## 根因
`/m3u`、`/interface.m3u` 之前返回 `Content-Type: audio/x-mpegurl`（可播放的 HLS 媒体类型），浏览器和飞牛订阅会把它当成视频去播放，而不是当订阅文本去解析。对比 GitHub raw 的 `.m3u`（返回 `text/plain`）飞牛可正常订阅。

## 改动
- `utils/appUtils.js`：`/m3u`、`/interface.m3u` 的 Content-Type 改为 `text/plain;charset=UTF-8`
- `app.js`：订阅接口补上 `X-Content-Type-Options: nosniff`，与 GitHub raw 对齐

## 影响 / 验证
- 普通播放器（DIYP / TiviMate 等）按正文 `#EXTM3U` 解析、忽略 Content-Type，零影响
- 本地实测 `/m3u` 与 `/interface.m3u` 响应头已变为 `text/plain;charset=UTF-8` + `nosniff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)