### PR TITLE
fix: 把 groupSortMode 纳入配置应用守卫，修复仅设组内按名称排序时不生效

### DIFF
--- a/utils/appUtils.js
+++ b/utils/appUtils.js
@@ -56,12 +56,13 @@ function interfaceStr(url, headers, urlUserId, urlToken, profile) {
 
       // 只有存在任意自定义配置时才应用（避免首次访问解析失败）
       // 注意：旧写法 `config.channelGroupMap` 恒真（{} 也为真），会导致始终套用配置；
-      // 这里改为按内容判断，并补上 groupRenameMap / customGroups
+      // 这里改为按内容判断，并补上 groupRenameMap / customGroups / groupSortMode
       if (config && (
         Object.keys(config.channelGroupMap || {}).length > 0 ||
         Object.keys(config.channelRenameMap || {}).length > 0 ||
         Object.keys(config.channelOrder || {}).length > 0 ||
         Object.keys(config.groupRenameMap || {}).length > 0 ||
+        Object.keys(config.groupSortMode || {}).length > 0 ||
         config.hiddenChannels?.length > 0 ||
         config.deletedGroups?.length > 0 ||
         config.customGroups?.length > 0 ||


### PR DESCRIPTION
## 问题
`utils/appUtils.js` 的 `interfaceStr()` 守卫只在“存在自定义配置”时才调用 `applyConfig` 重新生成 `/m3u`、`/txt`。但守卫判断的字段漏了 `groupSortMode`（该字段仅在 `applyConfig` 内被读取）。

后果：当用户**唯一**的改动是把某个分组设为「按名称排序」、其余配置全空时，保存成功，但 `/m3u`、`/txt` 请求会判定“无自定义配置”而跳过 `applyConfig` → 该排序不生效。

## 改动
守卫条件补一行 `Object.keys(config.groupSortMode || {}).length > 0`，与 `channelGroupMap` 等同源字段保持一致（单文件 2 行）。

## 验证
本地最小验证（已通过）：
- 守卫：仅含 `groupSortMode` 的配置——修复前判定 false（复现 bug），修复后判定 true。
- 端到端：`applyConfig` + `generateM3u8` 实跑，`groupSortMode='name'` 的组频道按名称数值排序（CCTV1→2→5→13）；空配置保持原顺序。

> 与 issue #20（乱码 / 移动没效果）无关，独立小修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)