### PR TITLE
feat: 后台/文档默认展示 /interface.m3u 订阅地址，提升可发现性 (issue #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ docker run -d -p 1905:1905 \
 部署成功后，可以通过以下地址访问：
 
 #### 📺 播放列表
-- **M3U 格式**: `http://your-ip:1905/m3u`
+- **M3U 格式**: `http://your-ip:1905/interface.m3u`（推荐：带 `.m3u` 后缀，部分 App 按后缀校验订阅地址才认；裸 `http://your-ip:1905/m3u` 内容相同、同样有效）
 - **TXT 格式**: `http://your-ip:1905/txt`
 - **节目单（EPG）**: `http://your-ip:1905/playback.xml`
 
@@ -482,13 +482,15 @@ docker run -d -p 1905:1905 \
 
 | 配置档 | M3U 地址 |
 | --- | --- |
-| 默认 | `http://你的IP:1905/m3u` |
-| 卧室(woshi) | `http://你的IP:1905/m3u?profile=woshi` |
-| 茶室(chashi) | `http://你的IP:1905/m3u?profile=chashi` |
+| 默认 | `http://你的IP:1905/interface.m3u` |
+| 卧室(woshi) | `http://你的IP:1905/interface.m3u?profile=woshi` |
+| 茶室(chashi) | `http://你的IP:1905/interface.m3u?profile=chashi` |
 
 > 💡 各档共享同一份底层频道与 EPG，只是「同一全集的不同视图」——隐藏 / 分组 / 排序 / 重命名各管各的，新增电视不增加抓取成本。
 >
-> 🔐 设了访问密码时地址带上 `/<密码>` 前缀即可：`http://你的IP:1905/<密码>/m3u?profile=woshi`。各档配置随 `mdataDir` 数据卷持久化，升级不丢。
+> 🔗 带 `.m3u` 后缀的 `/interface.m3u` 与裸 `/m3u` 内容完全相同、可互换；推荐用带后缀的（部分 App 按后缀校验才认），已用裸 `/m3u` 配好的地址无需更换。
+>
+> 🔐 设了访问密码时地址带上 `/<密码>` 前缀即可：`http://你的IP:1905/<密码>/interface.m3u?profile=woshi`。各档配置随 `mdataDir` 数据卷持久化，升级不丢。
 
 #### 🧹 空白部署 / 纯频道管理（内容开关）
 
@@ -572,7 +574,7 @@ mpass="yourpassword"
 
 | 服务 | 无密码访问 | 有密码访问 |
 |------|-----------|-----------|
-| 播放列表 (m3u) | `http://ip:port/m3u` | `http://ip:port/密码/m3u` |
+| 播放列表 (m3u) | `http://ip:port/interface.m3u` | `http://ip:port/密码/interface.m3u` |
 | 播放列表 (txt) | `http://ip:port/txt` | `http://ip:port/密码/txt` |
 | 回放文件 | `http://ip:port/playback.xml` | `http://ip:port/密码/playback.xml` |
 | 频道直播 | `http://ip:port/608807420` | `http://ip:port/密码/608807420` |

--- a/web/admin.html
+++ b/web/admin.html
@@ -1691,7 +1691,7 @@
             <input type="text" id="newProfileName" placeholder="卧室" autocomplete="off" maxlength="20"
                    onkeydown="if(event.key==='Enter'){document.getElementById('newProfileId').focus();}">
             <label style="display:block; font-size:13px; color:#333; margin-bottom:6px;">访问地址短名（选填，英文/数字）</label>
-            <input type="text" id="newProfileId" placeholder="woshi　→　/m3u?profile=woshi" autocomplete="off"
+            <input type="text" id="newProfileId" placeholder="woshi　→　/interface.m3u?profile=woshi" autocomplete="off"
                    onkeydown="if(event.key==='Enter'){confirmCreateProfile();}">
             <p style="color:#8a8a8a; font-size:12px; margin: -6px 0 4px;">💡 留空会自动生成短名（中文无法转拼音）。</p>
             <div class="modal-actions" style="margin-top: 20px;">
@@ -3451,7 +3451,9 @@ if(success){
             box.innerHTML = profileList.map(p => {
                 const isActive = p.id === activeProfile;
                 const isDefault = p.id === 'default';
-                const url = base + '/m3u' + (isDefault ? '' : '?profile=' + p.id);
+                // 默认展示带 .m3u 后缀的别名地址：内容与 /m3u 完全相同，但能被「按后缀校验订阅链接」的 App 接受；
+                // 普通播放器忽略后缀、行为不变。裸 /m3u 仍有效，老用户已配置的地址不受影响。
+                const url = base + '/interface.m3u' + (isDefault ? '' : '?profile=' + p.id);
                 const slugHtml = isDefault ? '' : ` <span style="color:#999;font-weight:normal;font-size:12px;">(${escapeHtml(p.id)})</span>`;
                 // 改名按钮紧跟档名右侧（默认档不可改名）
                 const renameBtn = isDefault ? '' :


### PR DESCRIPTION
## 背景 (issue #30, 亦见 #24)
`/interface.m3u`（带 `.m3u` 后缀、内容与 `/m3u` 完全相同）自 3.3.0 起就存在，但：
- 后台「配置档」弹窗复制的订阅地址一直是裸 `/m3u`；
- README 主使用说明也只写 `/m3u`，`/interface.m3u` 仅在更新日志提了一句。

结果用户在「按后缀校验订阅链接」的 App（飞牛影视等）上被拒，却**无从发现**还有带后缀的别名——这是可发现性缺口，导致同一问题被反复提（#24、#30）。

## 改动（纯展示层）
- 后台配置档弹窗复制的地址改为 `/interface.m3u`（带 profile 时 `/interface.m3u?profile=xx`）；新建档占位提示同步更新。
- README 播放列表 / 多档地址表 / 访问格式表几处改用 `/interface.m3u`，并注明裸 `/m3u` 等价、已配好的地址无需更换。

## 不影响老用户
`/m3u` 接口未做任何改动，仍然有效——已经把 `/m3u` 填进播放器/电视的用户继续正常使用，本 PR 只改「后台显示/复制」与文档展示。`.m3u` 后缀是超集兼容（更多 App 接受、普通播放器忽略后缀）。

## 验证
运行时确认 `/interface.m3u` 与 `/interface.m3u?profile=default` 均返回 200 + `text/plain` + 有效 m3u；后台页正常加载（200）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)