### PR TITLE
fix: 移动频道后无法隐藏（隐藏/移动按真实原始分组算 key）(issue #42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
-    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs"
+    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs && node scripts/test-move-hide.mjs"
   },
   "dependencies": {
     "node-fetch": "^3.3.2",

--- a/scripts/test-move-hide.mjs
+++ b/scripts/test-move-hide.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * 移动频道后隐藏的回归测试（issue #42）
+ *
+ * 不变量：隐藏 key 必须用频道「真实原始分组」(originalGroup)，即 `${originalGroup}::${id}`，
+ * 与服务端 applyConfig 的隐藏判定一致。移动过的频道其显示分组 ≠ 原始分组，
+ * 若按显示分组算 key（旧 bug），隐藏对它不生效。
+ *
+ * 运行： node scripts/test-move-hide.mjs   （或 npm test）
+ */
+import assert from 'node:assert/strict'
+import { applyConfig } from '../utils/playlistConfig.js'
+
+for (const k of ['log', 'info', 'warn']) {
+  const orig = console[k]
+  console[k] = (...a) => { if (a.some(x => typeof x === 'string' && /应用播放列表配置|配置应用完成/.test(x))) return; orig.apply(console, a) }
+}
+
+const groups = () => ([
+  { name: 'A', channels: [{ id: 'x1', name: 'X' }] },
+  { name: 'C', channels: [{ id: 'y1', name: 'Y' }] },
+])
+const base = () => ({ channelGroupMap: {}, channelRenameMap: {}, channelOrder: {}, hiddenChannels: [],
+  customGroups: [{ name: 'B' }], groupOrder: [], deletedGroups: [], groupRenameMap: {}, groupSortMode: {} })
+const shows = (cfg, name) => applyConfig(groups(), cfg).some(g => g.channels.some(c => c.name === name))
+
+let passed = 0
+const check = (name, fn) => { fn(); passed++; console.log(`  ✅ ${name}`) }
+
+console.log('移动后隐藏回归测试 (issue #42)')
+
+check('移动 A→B 后，X 显示在 B', () => {
+  const cfg = base(); cfg.channelGroupMap = { 'A::x1': 'B' }
+  assert.equal(shows(cfg, 'X'), true)
+})
+
+check('用「原始分组」key (A::x1) 隐藏 → 生效（X 不再显示）', () => {
+  const cfg = base(); cfg.channelGroupMap = { 'A::x1': 'B' }; cfg.hiddenChannels = ['A::x1']
+  assert.equal(shows(cfg, 'X'), false)
+})
+
+check('用「显示分组」key (B::x1) 隐藏 → 不生效（复现旧 bug，前端不可这样算）', () => {
+  const cfg = base(); cfg.channelGroupMap = { 'A::x1': 'B' }; cfg.hiddenChannels = ['B::x1']
+  assert.equal(shows(cfg, 'X'), true)
+})
+
+check('原分组 A 被搬空后，仍能用 A::x1 正确隐藏 X', () => {
+  // A 只有 x1，移走后 A 在显示层为空；隐藏仍按原始分组 A 算 key
+  const cfg = base(); cfg.channelGroupMap = { 'A::x1': 'B' }; cfg.hiddenChannels = ['A::x1']
+  assert.equal(shows(cfg, 'X'), false)
+})
+
+console.log(`\n全部通过：${passed}/4 ✅`)

--- a/scripts/test-move-hide.mjs
+++ b/scripts/test-move-hide.mjs
@@ -50,4 +50,23 @@ check('原分组 A 被搬空后，仍能用 A::x1 正确隐藏 X', () => {
   assert.equal(shows(cfg, 'X'), false)
 })
 
-console.log(`\n全部通过：${passed}/4 ✅`)
+// 批量移动同类不变量：再次移动「已移动过」的频道，必须改写原始分组那条键 A::x1
+const inGroup = (cfg, ch, grp) => applyConfig(groups(), cfg).find(g => g.name === grp)?.channels.some(c => c.name === ch)
+
+check('再次移动 B→C：改写 A::x1=C → X 落在 C', () => {
+  const cfg = base(); cfg.customGroups = [{ name: 'B' }, { name: 'C2' }]; cfg.channelGroupMap = { 'A::x1': 'C2' }
+  assert.equal(inGroup(cfg, 'X', 'C2'), true)
+})
+
+check('旧 bug 形态（孤儿键 B::x1=C2）→ X 仍卡在 B（前端不可这样写）', () => {
+  const cfg = base(); cfg.customGroups = [{ name: 'B' }, { name: 'C2' }]; cfg.channelGroupMap = { 'A::x1': 'B', 'B::x1': 'C2' }
+  assert.equal(inGroup(cfg, 'X', 'B'), true)
+  assert.equal(inGroup(cfg, 'X', 'C2'), false)
+})
+
+check('移回原组：删除 A::x1 → X 回到 A', () => {
+  const cfg = base() // 无 channelGroupMap = 已删除归类
+  assert.equal(inGroup(cfg, 'X', 'A'), true)
+})
+
+console.log(`\n全部通过：${passed}/7 ✅`)

--- a/web/admin.html
+++ b/web/admin.html
@@ -4327,9 +4327,17 @@ if(success){
             }
         }
 
+        // 隐藏/归类统一用频道「真实原始分组」(channel.originalGroup) 算 key：移动过的频道其显示分组 ≠ 原始分组，
+        // 而服务端 applyConfig 按 `${originalGroup}::${id}` 判定隐藏；用显示分组会写错 key，导致隐藏对移动过的频道不生效
+        // （issue #42）。找不到频道对象时退回按显示分组推算（兼容旧行为）。
+        function channelOriginalGroupName(channel, displayGroupName) {
+            return channel?.originalGroup || getOriginalGroupName(displayGroupName);
+        }
+
         async function hideChannel(channelId) {
             const group = myPlaylistData[selectedGroupIndex];
-            const originalGroupName = getOriginalGroupName(group.name);
+            const channel = group?.channels.find(c => c.id === channelId);
+            const originalGroupName = channelOriginalGroupName(channel, group.name);
             const hiddenKey = `${originalGroupName}::${channelId}`;
             if (!myPlaylistConfig.hiddenChannels.includes(hiddenKey)) {
                 myPlaylistConfig.hiddenChannels.push(hiddenKey);
@@ -4642,8 +4650,9 @@ if(success){
 
             // 将选中的频道添加到hiddenChannels（使用 分组名::频道ID 格式）
             const group = myPlaylistData[selectedGroupIndex];
-            const originalGroupName = getOriginalGroupName(group.name);
             selectedChannels.forEach(channelId => {
+                const channel = group?.channels.find(c => c.id === channelId);
+                const originalGroupName = channelOriginalGroupName(channel, group.name);
                 const hiddenKey = `${originalGroupName}::${channelId}`;
                 if (!myPlaylistConfig.hiddenChannels.includes(hiddenKey)) {
                     myPlaylistConfig.hiddenChannels.push(hiddenKey);
@@ -4727,10 +4736,10 @@ if(success){
             );
             if (!confirmed) return;
 
-            // 隐藏未选中的频道（使用 分组名::频道ID 格式）
-            const originalGroupName = getOriginalGroupName(group.name);
+            // 隐藏未选中的频道（按频道真实原始分组算 key，移动过的频道才能正确隐藏，见 issue #42）
             group.channels.forEach(channel => {
                 if (!selectedChannels.has(channel.id)) {
+                    const originalGroupName = channelOriginalGroupName(channel, group.name);
                     const hiddenKey = `${originalGroupName}::${channel.id}`;
                     if (!myPlaylistConfig.hiddenChannels.includes(hiddenKey)) {
                         myPlaylistConfig.hiddenChannels.push(hiddenKey);

--- a/web/admin.html
+++ b/web/admin.html
@@ -4688,13 +4688,16 @@ if(success){
             if (!sel) return;
             const target = sel.value;
             const group = myPlaylistData[selectedGroupIndex];
-            const originalGroupName = getOriginalGroupName(group.name);
-            const renamedOriginal = (myPlaylistConfig.groupRenameMap && myPlaylistConfig.groupRenameMap[originalGroupName]) || originalGroupName;
 
             if (!myPlaylistConfig.channelGroupMap) myPlaylistConfig.channelGroupMap = {};
             selectedChannels.forEach(channelId => {
-                const moveKey = `${originalGroupName}::${channelId}`;
-                if (target === renamedOriginal || target === originalGroupName) {
+                // 用频道真实原始分组算 moveKey：再次移动一个「已移动过」的频道时，显示分组 ≠ 原始分组，
+                // 必须按原始分组改写同一条 channelGroupMap 记录，否则会留下孤儿键、移动/移回失效（issue #42）。
+                const channel = group?.channels.find(c => c.id === channelId);
+                const chOriginal = channel?.originalGroup || getOriginalGroupName(group.name);
+                const chRenamedOriginal = (myPlaylistConfig.groupRenameMap && myPlaylistConfig.groupRenameMap[chOriginal]) || chOriginal;
+                const moveKey = `${chOriginal}::${channelId}`;
+                if (target === chRenamedOriginal || target === chOriginal) {
                     // 移回原分组 = 取消归类
                     delete myPlaylistConfig.channelGroupMap[moveKey];
                 } else {


### PR DESCRIPTION
## 修复 issue #42：移动频道后无法隐藏

### 根因
「我的频道」对频道的**隐藏**和**归类(移动)**都以 `原始分组::频道ID` 为 key，服务端 `applyConfig` 也按频道**真实原始分组**判定。但前端多处用了**当前显示分组**算 key：频道从原分组 A 移动到 B 后显示在 B，隐藏却写成 `B::id`，而判定查的是 `A::id` → 对不上 → 隐藏对移动过的频道**完全无效**（界面还提示"已隐藏"）。

### 改动
统一改用频道真实的 `channel.originalGroup` 算 key（新增 `channelOriginalGroupName` helper，找不到频道对象时回退旧逻辑、兼容）：

- **隐藏**：`hideChannel` / `hideSelectedChannels` / `keepSelectedChannels` —— 直接修复 #42 反馈的"移动后隐藏不生效"，并顺带解决"原分组被搬空后无法隐藏/恢复"（隐藏视图本就按原始分组渲染）。
- **批量移动**：`moveSelectedChannels` —— 同类潜在问题：对已移动过的频道再次批量移动 / 批量移回原组会写出孤儿键而失效，一并修正，与单频道移动 `moveCurrentChannel`（本就用原始分组）行为一致。

### 测试
新增 `scripts/test-move-hide.mjs`，`npm test` 全绿（分组 6 + 规整 10 + 移动隐藏 7）；admin.html 内联 JS 通过语法校验。

> 不含版本号变更——按维护者要求**先合并进 main、暂不发版**，攒后续改动统一发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q)_