### PR TITLE
feat: 导入本地 .txt/.m3u 文件批量添加直播源 (issue #43)

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ import { channel, interfaceStr } from "./utils/appUtils.js";
 import { dataPath } from "./utils/paths.js";
 import { getChannelsAPI, getExternalSourcesAPI, saveExternalSourcesAPI,
          addExternalSourceAPI, removeExternalSourceAPI, updateExternalSourceAPI,
-         setExternalSourceM3u8API, importSubscriptionAPI, getBuiltInSourcesAPI } from "./utils/adminAPI.js";
+         setExternalSourceM3u8API, importSubscriptionAPI, parseLocalContentAPI, getBuiltInSourcesAPI } from "./utils/adminAPI.js";
 import { getSystemConfigAPI, saveSystemConfigAPI } from "./utils/systemConfigAPI.js";
 import { readConfig, saveConfig, parseInterfaceTxt, validateGroupConfig, applyConfig,
          listProfiles, createProfile, renameProfile, deleteProfile } from "./utils/playlistConfig.js";
@@ -203,6 +203,8 @@ const server = http.createServer(async (req, res) => {
           result = setExternalSourceM3u8API(data.index, data.m3u8Url)
         } else if (data.action === 'importSubscription') {
           result = await importSubscriptionAPI(data.index)
+        } else if (data.action === 'parseLocalContent') {
+          result = parseLocalContentAPI(data.contentBase64)
         } else {
           result = { success: false, message: '未知操作' }
         }

--- a/utils/adminAPI.js
+++ b/utils/adminAPI.js
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs"
 import { getAllChannels, externalSourceManager, builtInSourceManager } from "./channelMerger.js"
-import { BUILT_IN_SUBSCRIPTIONS } from "./externalSources.js"
+import { BUILT_IN_SUBSCRIPTIONS, parsePlaylistContent, decodeAndParseLocalContent } from "./externalSources.js"
 import { dataPath } from "./paths.js"
 import update from "./updateData.js"
 
@@ -103,6 +103,14 @@ export function getExternalSourcesAPI() {
  */
 export async function saveExternalSourcesAPI(sources) {
   try {
+    // 本地导入源（内联 subscriptionContent）：保存前用内容重新解析出频道，保证 parsedChannels 与内容一致（issue #43）
+    if (sources && Array.isArray(sources.sources)) {
+      for (const s of sources.sources) {
+        if (s && s.mode === 'subscription' && typeof s.subscriptionContent === 'string' && s.subscriptionContent.trim()) {
+          s.parsedChannels = parsePlaylistContent(s.subscriptionContent)
+        }
+      }
+    }
     const result = externalSourceManager.saveSources(sources)
     if (result.success !== false) {
       // 保存成功后自动触发更新，仅重新生成播放列表（不重新抓取咪咕数据）
@@ -178,6 +186,18 @@ export function setExternalSourceM3u8API(index, m3u8Url) {
       success: false,
       message: error.message
     }
+  }
+}
+
+/**
+ * 解析本地导入的播放列表内容（base64 字节）：解码（GBK/UTF/BOM）+ 解析 m3u/txt，返回解码后文本与频道数（issue #43）
+ */
+export function parseLocalContentAPI(contentBase64) {
+  try {
+    const { text, channels } = decodeAndParseLocalContent(contentBase64)
+    return { success: true, text, channelCount: channels.length }
+  } catch (error) {
+    return { success: false, message: error.message }
   }
 }
 

--- a/utils/externalSources.js
+++ b/utils/externalSources.js
@@ -151,6 +151,19 @@ function decodeSubscriptionBody(buffer, contentType) {
 }
 
 /**
+ * 解码并解析「本地导入」的播放列表字节（base64）。复用订阅的字节解码（BOM/charset/UTF-8 试解/GBK 回退）
+ * 与 m3u/txt 解析，使本地上传的文件与在线订阅得到一致的编码处理与频道结构（issue #43）。
+ * @param {string} base64 - 文件原始字节的 base64
+ * @returns {{ text: string, channels: Array }}
+ */
+function decodeAndParseLocalContent(base64) {
+  const buffer = Buffer.from(String(base64 || ''), 'base64')
+  const text = decodeSubscriptionBody(buffer, null)
+  const channels = parsePlaylistContent(text)
+  return { text, channels }
+}
+
+/**
  * 将 raw.githubusercontent.com 地址转换为 jsdelivr 格式 /gh/owner/repo@branch/path
  */
 function toJsdelivr(url, base) {
@@ -553,6 +566,16 @@ class ExternalSourceManager {
    */
   async updateSubscriptionSource(index) {
     const source = this.sources.sources[index]
+    // 本地导入源：内容已内联在 subscriptionContent，直接本地解析、不发网络请求（issue #43）
+    if (typeof source.subscriptionContent === 'string' && source.subscriptionContent.trim()) {
+      const channels = parsePlaylistContent(source.subscriptionContent)
+      this.sources.sources[index].parsedChannels = channels
+      this.sources.sources[index].lastUpdated = new Date().toISOString()
+      this.sources.sources[index]._failCount = 0
+      this.saveSources()
+      printGreen(`${source.name} 本地导入解析成功，共 ${channels.length} 个频道`)
+      return { success: true, channelCount: channels.length }
+    }
     if (!source.subscriptionUrl) {
       return { success: false, message: '未填写订阅地址' }
     }
@@ -804,4 +827,4 @@ class ExternalSourceManager {
 const externalSourceManager = new ExternalSourceManager()
 
 export default externalSourceManager
-export { ExternalSourceManager, fetchAndParseM3u, parsePlaylistContent, splitCredentials, isBuiltInSubscriptionSource, GITHUB_RAW_MIRRORS, BUILT_IN_SUBSCRIPTIONS }
+export { ExternalSourceManager, fetchAndParseM3u, parsePlaylistContent, decodeAndParseLocalContent, splitCredentials, isBuiltInSubscriptionSource, GITHUB_RAW_MIRRORS, BUILT_IN_SUBSCRIPTIONS }

--- a/web/admin.html
+++ b/web/admin.html
@@ -2552,9 +2552,19 @@
                             <input type="text" value="${source.name || ''}" oninput="updateExternalField(${index}, 'name', this.value)" placeholder="例：广东电视台直播源">
                         </div>
                         <div class="external-field">
-                            <label>订阅地址 *</label>
+                            <label>来源 *</label>
+                            <div class="mode-switcher" style="margin-bottom: 8px;">
+                                <button class="mode-switch-btn ${!source.localImport ? 'active' : ''}" onclick="setSubImportType(${index}, false)">🌐 在线 URL</button>
+                                <button class="mode-switch-btn ${source.localImport ? 'active' : ''}" onclick="setSubImportType(${index}, true)">📁 本地文件 / 粘贴</button>
+                            </div>
+                            ${!source.localImport ? `
                             <input type="text" value="${source.subscriptionUrl || ''}" oninput="updateExternalField(${index}, 'subscriptionUrl', this.value)" placeholder="例：https://example.com/playlist.m3u 或 .txt">
                             <div class="form-hint">填写包含多个频道的 m3u/m3u8 或 txt（频道名,地址）播放列表地址，系统会自动识别格式并解析其中的所有频道</div>
+                            ` : `
+                            <input type="file" accept=".m3u,.m3u8,.txt,text/plain" onchange="onLocalFilePicked(${index}, this)" style="margin-bottom: 8px;">
+                            <textarea oninput="updateExternalField(${index}, 'subscriptionContent', this.value)" placeholder="选择本地 .m3u/.m3u8/.txt 文件，或直接把播放列表内容粘贴到这里（支持 m3u/m3u8 与 txt「频道名,地址」格式，自动识别 GBK/UTF-8 编码）" style="width: 100%; min-height: 120px; font-family: monospace; font-size: 12px; box-sizing: border-box;">${(source.subscriptionContent || '').replace(/&/g, '&amp;').replace(/</g, '&lt;')}</textarea>
+                            <div class="form-hint">选择文件或粘贴内容后，点下方「📥 导入并保存」即可解析入库；本地导入不发起网络请求</div>
+                            `}
                             ${channelInfo}
                         </div>
                         <div class="external-field">
@@ -2652,7 +2662,10 @@
             
             // 切换模式
             source.mode = newMode;
-            
+            // 切换模式时清掉本地导入内容/标记（订阅模式内再单独选「URL / 本地」）
+            source.subscriptionContent = '';
+            source.localImport = false;
+
             // 根据新模式清空对应的URL字段
             if (newMode === 'fetch') {
                 // 切换到抓取模式，清空m3u8Url
@@ -2687,6 +2700,55 @@
             
             // 重新渲染详情面板
             renderExternalDetail(index);
+        }
+
+        // 订阅源「来源」切换：在线 URL / 本地文件·粘贴（issue #43）
+        function setSubImportType(index, isLocal) {
+            const source = externalConfig.sources[index];
+            if (!source) return;
+            source.localImport = !!isLocal;
+            renderExternalDetail(index);
+        }
+
+        // ArrayBuffer -> base64（分块，避免大文件 String.fromCharCode 爆栈）
+        function arrayBufferToBase64(buffer) {
+            const bytes = new Uint8Array(buffer);
+            let binary = '';
+            const chunk = 0x8000;
+            for (let i = 0; i < bytes.length; i += chunk) {
+                binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+            }
+            return btoa(binary);
+        }
+
+        // 选择本地 m3u/txt 文件：读原始字节交后端解码(GBK/UTF/BOM)并预览频道数，结果填入内容框
+        async function onLocalFilePicked(index, inputEl) {
+            const file = inputEl.files && inputEl.files[0];
+            if (!file) return;
+            const source = externalConfig.sources[index];
+            if (!source) return;
+            try {
+                showStatus('正在读取文件...', 'info');
+                const base64 = arrayBufferToBase64(await file.arrayBuffer());
+                const resp = await fetch(API_PREFIX + '/api/external-sources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'parseLocalContent', contentBase64: base64 })
+                });
+                const result = await resp.json();
+                if (result.success === false) {
+                    showStatus('文件解析失败: ' + (result.message || ''), 'error');
+                    return;
+                }
+                source.subscriptionContent = result.text || '';
+                if (!source.name || !source.name.trim()) {
+                    source.name = file.name.replace(/\.(m3u8?|txt)$/i, '');
+                }
+                renderExternalDetail(index);
+                showStatus(`已读取「${file.name}」，识别到 ${result.channelCount || 0} 个频道，点「📥 导入并保存」入库`, 'success');
+            } catch (e) {
+                showStatus('读取文件失败: ' + e.message, 'error');
+            }
         }
 
         // 自定义确认对话框
@@ -3009,8 +3071,10 @@
                 showStatus('请填写订阅名称', 'error');
                 return;
             }
-            if (!source.subscriptionUrl || !source.subscriptionUrl.trim()) {
-                showStatus('请填写订阅地址', 'error');
+            const hasUrl = source.subscriptionUrl && source.subscriptionUrl.trim();
+            const hasContent = source.subscriptionContent && source.subscriptionContent.trim();
+            if (!hasUrl && !hasContent) {
+                showStatus(source.localImport ? '请选择本地文件或粘贴播放列表内容' : '请填写订阅地址', 'error');
                 return;
             }
             


### PR DESCRIPTION
## 功能：导入本地 .txt / .m3u 文件批量加源（issue #43）

在「添加源 → 订阅模式」新增**「来源」切换：🌐 在线 URL / 📁 本地文件·粘贴**。本地导入**复用订阅的整套管线**（m3u/m3u8 + txt 自动识别、GBK/UTF-8/BOM 编码处理、分组、开关、以及已有的 EPG 规整 / 台标），只是把"内容来源"从远程 URL 换成上传文件或粘贴文本，**不发起网络请求**。

### 后端
- `externalSources.js`：新增 `decodeAndParseLocalContent`（base64 字节 → 解码 → 解析）；`updateSubscriptionSource` 增加本地分支（有 `subscriptionContent` 就本地解析、不抓取）。
- `adminAPI.js`：`parseLocalContentAPI`（解码 + 预览频道数）；`saveExternalSourcesAPI` 保存前用 `subscriptionContent` 重新解析出 `parsedChannels`，保证一致。
- `app.js`：注册 `parseLocalContent` action。

### 前端（admin.html）
- 订阅编辑器加「URL / 本地文件·粘贴」切换；本地模式给文件选择 + 内容文本框（可直接粘贴）。
- 文件按**原始字节**读取 → 交后端解码（中文 GBK 列表不乱码）→ 回填内容并预览频道数。
- 导入校验改为「URL 或 内容」二选一；切换模式时清理本地导入残留。

### 验证
本地解析（UTF-8 m3u、UTF-8 txt(diyp/genre)、**GBK txt**、BOM）已用真实函数端到端验证通过；后端/前端内联 JS 均过语法校验。

> 未加 `npm test` 回归测试：`externalSources.js` 依赖 `node-fetch`/`puppeteer`，而仓库现有轻量测试均不依赖 node_modules；故本地导入解析以手动端到端验证为准。
>
> 不含版本号变更——按维护者要求**先合并进 main、暂不发版**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q)_