### PR TITLE
feat: 后台上传/预览频道台标，存 data/logos 即时生效 (issue #40 第一步)

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,8 @@ import { channel, interfaceStr } from "./utils/appUtils.js";
 import { dataPath } from "./utils/paths.js";
 import { getChannelsAPI, getExternalSourcesAPI, saveExternalSourcesAPI,
          addExternalSourceAPI, removeExternalSourceAPI, updateExternalSourceAPI,
-         setExternalSourceM3u8API, importSubscriptionAPI, parseLocalContentAPI, getBuiltInSourcesAPI } from "./utils/adminAPI.js";
+         setExternalSourceM3u8API, importSubscriptionAPI, parseLocalContentAPI,
+         uploadLogoAPI, removeLogoAPI, getBuiltInSourcesAPI } from "./utils/adminAPI.js";
 import { getSystemConfigAPI, saveSystemConfigAPI } from "./utils/systemConfigAPI.js";
 import { readConfig, saveConfig, parseInterfaceTxt, validateGroupConfig, applyConfig,
          listProfiles, createProfile, renameProfile, deleteProfile } from "./utils/playlistConfig.js";
@@ -212,6 +213,32 @@ const server = http.createServer(async (req, res) => {
         res.writeHead(result.success ? 200 : 500, { 'Content-Type': 'application/json;charset=UTF-8' });
         res.end(JSON.stringify(result));
         printGreen(`外部源${data.action}操作完成`)
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify({ success: false, message: error.message }));
+      }
+      return
+    }
+
+    // 上传 / 移除频道台标（issue #40）
+    if (routePath === '/api/upload-logo' && method === 'POST') {
+      try {
+        const data = JSON.parse(await readBody(req))
+        const result = await uploadLogoAPI(data.name, data.imageBase64, data.ext)
+        res.writeHead(result.success ? 200 : 400, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify(result));
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify({ success: false, message: error.message }));
+      }
+      return
+    }
+    if (routePath === '/api/remove-logo' && method === 'POST') {
+      try {
+        const data = JSON.parse(await readBody(req))
+        const result = await removeLogoAPI(data.name)
+        res.writeHead(result.success ? 200 : 400, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify(result));
       } catch (error) {
         res.writeHead(400, { 'Content-Type': 'application/json;charset=UTF-8' });
         res.end(JSON.stringify({ success: false, message: error.message }));

--- a/utils/adminAPI.js
+++ b/utils/adminAPI.js
@@ -1,8 +1,8 @@
-import { readFileSync, writeFileSync, existsSync } from "node:fs"
+import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from "node:fs"
 import { getAllChannels, externalSourceManager, builtInSourceManager } from "./channelMerger.js"
 import { BUILT_IN_SUBSCRIPTIONS, parsePlaylistContent, decodeAndParseLocalContent } from "./externalSources.js"
 import { dataPath } from "./paths.js"
-import update from "./updateData.js"
+import update, { LOGO_EXTS } from "./updateData.js"
 
 /**
  * 从interface.txt解析体育赛事数据
@@ -186,6 +186,63 @@ export function setExternalSourceM3u8API(index, m3u8Url) {
       success: false,
       message: error.message
     }
+  }
+}
+
+/**
+ * 校验台标文件名（= 频道名）：不能含路径分隔符 / 控制字符，避免目录穿越
+ */
+function sanitizeLogoName(name) {
+  const n = String(name || '').trim()
+  if (!n || n.includes('/') || n.includes('\\') || n.includes('..')) return null
+  for (let i = 0; i < n.length; i++) { if (n.charCodeAt(i) < 32) return null } // 拒绝控制字符
+  return n
+}
+
+/**
+ * 上传频道台标（issue #40）：把图片存为 data/logos/<频道名>.<ext>，最高优先级、即时生效。
+ * 同一频道只保留一个台标（先删其它扩展名），保存后重新生成播放列表。
+ */
+export async function uploadLogoAPI(name, imageBase64, ext) {
+  try {
+    const safe = sanitizeLogoName(name)
+    if (!safe) return { success: false, message: '频道名含非法字符，无法作为台标文件名' }
+    let e = String(ext || 'png').toLowerCase().replace(/[^a-z0-9]/g, '')
+    if (!LOGO_EXTS.includes(e)) e = 'png'
+    const buffer = Buffer.from(String(imageBase64 || ''), 'base64')
+    if (!buffer.length) return { success: false, message: '图片内容为空' }
+    if (buffer.length > 3 * 1024 * 1024) return { success: false, message: '图片过大（请小于 3MB）' }
+    const dir = dataPath('logos')
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    // 一个频道只保留一个台标：先清掉同名其它扩展，避免 findLocalLogo 命中旧的
+    for (const x of LOGO_EXTS) {
+      const p = dataPath(`logos/${safe}.${x}`)
+      if (existsSync(p)) { try { unlinkSync(p) } catch { /* ignore */ } }
+    }
+    writeFileSync(dataPath(`logos/${safe}.${e}`), buffer)
+    await update(0, { regenerateOnly: true }).catch(err => console.error('上传台标后重新生成失败:', err))
+    return { success: true, url: `/logos/${encodeURIComponent(safe)}.${e}` }
+  } catch (error) {
+    return { success: false, message: error.message }
+  }
+}
+
+/**
+ * 移除频道的本地上传台标（删 data/logos/<频道名>.* 后重新生成）
+ */
+export async function removeLogoAPI(name) {
+  try {
+    const safe = sanitizeLogoName(name)
+    if (!safe) return { success: false, message: '非法名称' }
+    let removed = 0
+    for (const x of LOGO_EXTS) {
+      const p = dataPath(`logos/${safe}.${x}`)
+      if (existsSync(p)) { try { unlinkSync(p); removed++ } catch { /* ignore */ } }
+    }
+    if (removed > 0) await update(0, { regenerateOnly: true }).catch(err => console.error('移除台标后重新生成失败:', err))
+    return { success: true, removed }
+  } catch (error) {
+    return { success: false, message: error.message }
   }
 }
 

--- a/utils/updateData.js
+++ b/utils/updateData.js
@@ -11,6 +11,20 @@ import { readFileSync, existsSync } from "node:fs"
 
 const PE_CACHE_PATH = dataPath('pe-cache.json')
 
+// 本地台标支持的扩展名（按优先级查找）
+export const LOGO_EXTS = ['png', 'jpg', 'jpeg', 'webp']
+
+// 查找本地台标 data/logos/<频道名>.<ext>（用户在后台上传或手动放），命中返回可写入 m3u 的相对 URL，否则 ''
+export function findLocalLogo(name) {
+  if (!name) return ''
+  for (const ext of LOGO_EXTS) {
+    if (existsSync(dataPath(`logos/${name}.${ext}`))) {
+      return `\${replace}/logos/${encodeURIComponent(name)}.${ext}`
+    }
+  }
+  return ''
+}
+
 /**
  * @param {Number} hours -更新小时数
  * @param {Object} options - 更新选项
@@ -124,15 +138,14 @@ async function updateTV(hours, options = {}) {
       
       const isBuiltIn = channelItem.source === 'built-in'
       const isExternal = channelItem.source === 'external' || !!channelItem.url
-      let logoUrl = channelItem.pics?.highResolutionH || channelItem.logo || ""
-      // 外部/精选频道（IPTV.m3u 等）多数没台标。优先级：m3u 手写(channelItem.logo，上面已取) >
-      // 本地 logos/<中文名>.png（用户自放，持久化在数据目录，仅查本地文件不联网）> fanmingming 兜底 > 空。
-      if (!logoUrl && (isExternal || isBuiltIn)) {
-        if (existsSync(dataPath(`logos/${channelItem.name}.png`))) {
-          logoUrl = `\${replace}/logos/${encodeURIComponent(channelItem.name)}.png`
-        } else if (externalLogoBase) {
-          logoUrl = `${externalLogoBase}${encodeURIComponent(channelItem.name)}.png`
-        }
+      // 台标优先级：本地 logos/<频道名>.<ext>（用户后台上传或手动放，最高、仅查本地不联网）
+      //   > 源自带台标（咪咕 pics / m3u 手写）> fanmingming 兜底（仅外部/内置）> 空。
+      let logoUrl = findLocalLogo(channelItem.name)
+      if (!logoUrl) {
+        logoUrl = channelItem.pics?.highResolutionH || channelItem.logo || ""
+      }
+      if (!logoUrl && (isExternal || isBuiltIn) && externalLogoBase) {
+        logoUrl = `${externalLogoBase}${encodeURIComponent(channelItem.name)}.png`
       }
       
       // 内置源使用playURL字段，外部源使用url字段，咪咕源构造URL

--- a/web/admin.html
+++ b/web/admin.html
@@ -5031,6 +5031,22 @@ if(success){
                         <div style="margin-top: 6px; color: #999; font-size: 12px;">修改此频道的显示名（清空或改回原名即恢复；不影响 EPG 匹配）</div>
                     </div>
                 `;
+
+                // 台标：预览 + 上传 / 移除（issue #40）
+                const _logoBaseUrl = window.location.origin + window.location.pathname.replace(/\/[^/]+$/, '');
+                const _logoSrc = channel.logo ? String(channel.logo).replace(/\$\{replace\}/g, _logoBaseUrl) : '';
+                detailHTML += `
+                    <div style="margin-bottom: 15px;">
+                        <strong style="color: #667eea;">台标：</strong>
+                        <div style="display:flex; align-items:center; gap:10px; margin-top:6px;">
+                            <img id="channelLogoPreview" src="${_logoSrc}" alt="" style="width:48px;height:48px;object-fit:contain;border:1px solid #eee;border-radius:6px;background:#fafafa;${_logoSrc ? '' : 'display:none;'}" onerror="this.style.display='none';var e=document.getElementById('channelLogoEmpty');if(e)e.style.display='';">
+                            <span id="channelLogoEmpty" style="color:#999;font-size:12px;${_logoSrc ? 'display:none;' : ''}">暂无台标</span>
+                            <input type="file" accept="image/png,image/jpeg,image/webp" onchange="uploadCurrentChannelLogo(this)">
+                            <button class="btn btn-sm btn-danger" onclick="removeCurrentChannelLogo()">移除</button>
+                        </div>
+                        <div style="margin-top:6px;color:#999;font-size:12px;">上传图片保存为 data/logos/「${String(channel.name || '').replace(/&/g, '&amp;').replace(/</g, '&lt;')}」，优先级最高、保存即生效（支持 png/jpg/webp，&lt;3MB）</div>
+                    </div>
+                `;
             }
 
             // 显示URL
@@ -5137,6 +5153,53 @@ if(success){
         function closeChannelDetail() {
             document.getElementById('channelDetailModal').style.display = 'none';
             currentChannelDetail = null;
+        }
+
+        // 上传当前频道台标（issue #40）：存 data/logos/<频道名>.<ext>，最高优先级、保存即生效
+        async function uploadCurrentChannelLogo(inputEl) {
+            const file = inputEl.files && inputEl.files[0];
+            if (!file || !currentChannelDetail) return;
+            if (file.size > 3 * 1024 * 1024) { showStatus('图片过大（请小于 3MB）', 'error'); inputEl.value = ''; return; }
+            const name = currentChannelDetail.name;
+            const ext = (file.name.split('.').pop() || 'png').toLowerCase();
+            try {
+                showStatus('正在上传台标...', 'info');
+                const base64 = arrayBufferToBase64(await file.arrayBuffer());
+                const resp = await fetch(API_PREFIX + '/api/upload-logo', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name, imageBase64: base64, ext })
+                });
+                const result = await resp.json();
+                if (result.success === false) { showStatus('上传失败: ' + (result.message || ''), 'error'); return; }
+                const baseUrl = window.location.origin + window.location.pathname.replace(/\/[^/]+$/, '');
+                const img = document.getElementById('channelLogoPreview');
+                const empty = document.getElementById('channelLogoEmpty');
+                if (img) { img.src = baseUrl + result.url + '?t=' + Date.now(); img.style.display = ''; }
+                if (empty) empty.style.display = 'none';
+                showStatus('台标已上传并生效', 'success');
+                const channelsRes = await fetch(API_PREFIX + '/api/channels');
+                if (channelsRes.ok) { allChannels = await channelsRes.json(); }
+            } catch (e) { showStatus('上传失败: ' + e.message, 'error'); }
+        }
+
+        // 移除当前频道的本地上传台标
+        async function removeCurrentChannelLogo() {
+            if (!currentChannelDetail) return;
+            try {
+                const resp = await fetch(API_PREFIX + '/api/remove-logo', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name: currentChannelDetail.name })
+                });
+                const result = await resp.json();
+                if (result.success === false) { showStatus('移除失败: ' + (result.message || ''), 'error'); return; }
+                const img = document.getElementById('channelLogoPreview');
+                const empty = document.getElementById('channelLogoEmpty');
+                if (img) { img.src = ''; img.style.display = 'none'; }
+                if (empty) empty.style.display = '';
+                showStatus(result.removed > 0 ? '已移除上传的台标' : '该频道没有本地上传的台标', result.removed > 0 ? 'success' : 'info');
+                const channelsRes = await fetch(API_PREFIX + '/api/channels');
+                if (channelsRes.ok) { allChannels = await channelsRes.json(); }
+            } catch (e) { showStatus('移除失败: ' + e.message, 'error'); }
         }
 
         // 将当前详情中的频道移动到所选分组（单频道归类）


### PR DESCRIPTION
## 第一步（issue #40）：后台上传 / 预览频道台标，即时生效

落地 #40 评论里 LIUBANGJIAN 的诉求——「没配对上的频道能在 web 页面自行添加 logo，保存到 `./data/logos/` 即时生效」。

### 改动
- **频道详情弹窗新增「台标」区**：预览当前台标 + 选图上传 + 移除。上传按 `data/logos/<频道名>.<ext>` 保存（png/jpg/webp，<3MB），保存后 `regenerateOnly` 重新生成播放列表即生效，无需重启。
- **台标优先级调整**：本地 `logos/<频道名>.<ext>`（用户上传/自放）提为**最高优先级**，其次源自带台标（咪咕 pics / m3u 手写），再 fanmingming 兜底；并支持 **png/jpg/jpeg/webp 多扩展名**（原仅 `.png`），统一封装为 `findLocalLogo`。
- **后端**：`adminAPI` 新增 `uploadLogoAPI` / `removeLogoAPI`（文件名校验防目录穿越、同频道仅留一个台标、写入后重新生成）；`app.js` 注册 `/api/upload-logo`、`/api/remove-logo`。

### 验证
`findLocalLogo`（扩展名优先 / URL 编码）与 `sanitizeLogoName`（正常名含 `-`/空格/`+` 通过、路径穿越与控制字符拒绝）逻辑已独立验证；4 个改动文件均过语法校验、无嵌入控制字节。

> 这是 #40 三步里的**第一步**（后台上传+预览）。第二、三步（多台标源兜底、内置 lopelduo 的台标包）待后续。
>
> 不含版本号变更——按维护者要求**先合并进 main、暂不发版**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q)_