### PR TITLE
feat: 频道详情「复制到分组」，把频道复制到多个分组 (issue #37)

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ import { dataPath } from "./utils/paths.js";
 import { getChannelsAPI, getExternalSourcesAPI, saveExternalSourcesAPI,
          addExternalSourceAPI, removeExternalSourceAPI, updateExternalSourceAPI,
          setExternalSourceM3u8API, importSubscriptionAPI, parseLocalContentAPI,
-         uploadLogoAPI, removeLogoAPI, getBuiltInSourcesAPI } from "./utils/adminAPI.js";
+         uploadLogoAPI, removeLogoAPI, copyChannelToGroupsAPI, getBuiltInSourcesAPI } from "./utils/adminAPI.js";
 import { getSystemConfigAPI, saveSystemConfigAPI } from "./utils/systemConfigAPI.js";
 import { readConfig, saveConfig, parseInterfaceTxt, validateGroupConfig, applyConfig,
          listProfiles, createProfile, renameProfile, deleteProfile } from "./utils/playlistConfig.js";
@@ -237,6 +237,20 @@ const server = http.createServer(async (req, res) => {
       try {
         const data = JSON.parse(await readBody(req))
         const result = await removeLogoAPI(data.name)
+        res.writeHead(result.success ? 200 : 400, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify(result));
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify({ success: false, message: error.message }));
+      }
+      return
+    }
+
+    // 复制频道到一个/多个分组（issue #37）
+    if (routePath === '/api/copy-channel' && method === 'POST') {
+      try {
+        const data = JSON.parse(await readBody(req))
+        const result = await copyChannelToGroupsAPI(data)
         res.writeHead(result.success ? 200 : 400, { 'Content-Type': 'application/json;charset=UTF-8' });
         res.end(JSON.stringify(result));
       } catch (error) {

--- a/utils/adminAPI.js
+++ b/utils/adminAPI.js
@@ -247,6 +247,29 @@ export async function removeLogoAPI(name) {
 }
 
 /**
+ * 把一个频道（同名同地址）复制到一个或多个分组（issue #37）：每个目标分组建一条独立的「直连」副本。
+ * 副本是固定地址的独立频道（独立隐藏/排序/删除）；咪咕频道地址为服务端跳转，暂不支持。
+ */
+export async function copyChannelToGroupsAPI({ name, url, logo, groups } = {}) {
+  try {
+    if (!name || !url) return { success: false, message: '缺少频道名或地址' }
+    if (String(url).includes('${replace}')) return { success: false, message: '咪咕频道暂不支持复制（地址为服务端跳转）' }
+    const targets = Array.isArray(groups) ? [...new Set(groups.map(g => String(g || '').trim()).filter(Boolean))] : []
+    if (!targets.length) return { success: false, message: '未选择目标分组' }
+    const safeLogo = (typeof logo === 'string' && /^https?:\/\//.test(logo)) ? logo : ''
+    let added = 0
+    for (const group of targets) {
+      externalSourceManager.addSource({ name, group, m3u8Url: url, logo: safeLogo, enabled: true, autoRefresh: false })
+      added++
+    }
+    await update(0, { regenerateOnly: true }).catch(err => console.error('复制频道后重新生成失败:', err))
+    return { success: true, added }
+  } catch (error) {
+    return { success: false, message: error.message }
+  }
+}
+
+/**
  * 解析本地导入的播放列表内容（base64 字节）：解码（GBK/UTF/BOM）+ 解析 m3u/txt，返回解码后文本与频道数（issue #43）
  */
 export function parseLocalContentAPI(contentBase64) {

--- a/web/admin.html
+++ b/web/admin.html
@@ -5032,6 +5032,22 @@ if(success){
                     </div>
                 `;
 
+                // 复制到分组（issue #37）：仅对地址固定的非咪咕频道提供
+                if (channel.url && !String(channel.url).includes('${replace}')) {
+                    const _copyGroups = myPlaylistData.map(g => g.name).filter(n => n !== groupName);
+                    if (_copyGroups.length) {
+                        const _copyOpts = _copyGroups.map(n => `<option value="${String(n).replace(/"/g, '&quot;')}">${n}</option>`).join('');
+                        detailHTML += `
+                            <div style="margin-bottom: 15px;">
+                                <strong style="color: #667eea;">复制到分组：</strong>
+                                <select id="channelCopySelect" multiple size="4" style="min-width:200px;padding:4px;border-radius:4px;border:1px solid #ddd;vertical-align:top;">${_copyOpts}</select>
+                                <button class="btn btn-sm btn-primary" style="margin-left:8px;vertical-align:top;" onclick="copyCurrentChannelToGroups()">复制</button>
+                                <div style="margin-top:6px;color:#999;font-size:12px;">把本频道（同名同地址）复制一份到所选分组（按住 Ctrl/Cmd 可多选）。复制出的是<b>固定地址的独立频道</b>，适合地址不变的频道；可在「外部源管理」里删除。</div>
+                            </div>
+                        `;
+                    }
+                }
+
                 // 台标：预览 + 上传 / 移除（issue #40）
                 const _logoBaseUrl = window.location.origin + window.location.pathname.replace(/\/[^/]+$/, '');
                 const _logoSrc = channel.logo ? String(channel.logo).replace(/\$\{replace\}/g, _logoBaseUrl) : '';
@@ -5200,6 +5216,31 @@ if(success){
                 const channelsRes = await fetch(API_PREFIX + '/api/channels');
                 if (channelsRes.ok) { allChannels = await channelsRes.json(); }
             } catch (e) { showStatus('移除失败: ' + e.message, 'error'); }
+        }
+
+        // 复制当前频道到所选分组（issue #37）：后端为每个目标分组建一条独立的直连副本
+        async function copyCurrentChannelToGroups() {
+            if (!currentChannelDetail) return;
+            const sel = document.getElementById('channelCopySelect');
+            if (!sel) return;
+            const groups = Array.from(sel.selectedOptions).map(o => o.value);
+            if (!groups.length) { showStatus('请先选择目标分组', 'error'); return; }
+            try {
+                showStatus('正在复制...', 'info');
+                const resp = await fetch(API_PREFIX + '/api/copy-channel', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name: currentChannelDetail.name, url: currentChannelDetail.url, logo: currentChannelDetail.logo || '', groups })
+                });
+                const result = await resp.json();
+                if (result.success === false) { showStatus('复制失败: ' + (result.message || ''), 'error'); return; }
+                showStatus(`已复制到 ${result.added} 个分组`, 'success');
+                closeChannelDetail();
+                const externalRes = await fetch(API_PREFIX + '/api/external-sources');
+                if (externalRes.ok) { externalConfig = normalizeExternalConfig(await externalRes.json()); }
+                await loadMyPlaylist(false);
+                const channelsRes = await fetch(API_PREFIX + '/api/channels');
+                if (channelsRes.ok) { allChannels = await channelsRes.json(); }
+            } catch (e) { showStatus('复制失败: ' + e.message, 'error'); }
         }
 
         // 将当前详情中的频道移动到所选分组（单频道归类）


### PR DESCRIPTION
## 功能（issue #37）：把频道复制到多个分组

满足 LIUBANGJIAN 的诉求——「让自己的频道同时出现在多个分组」（例如 TVB 同时在「亚太」和「香港」）。

实现为 **「真复制」**：为每个目标分组建一条**独立的直连副本**（同名同地址），各分组里是独立的一份，**隐藏/排序/删除互不影响**——规避了"虚拟多分组"会遇到的共享 key（按 `原始分组::ID` 记的隐藏/排序会串）的问题。

### 改动
- **后端** `adminAPI.copyChannelToGroupsAPI`：校验（缺字段 / 咪咕地址拒绝）、目标分组去重去空、logo 仅保留 http 地址，逐组 `addSource` 建直连副本后 `regenerateOnly` 重新生成；`app.js` 注册 `/api/copy-channel`。
- **前端**：频道详情弹窗加「复制到分组」**多选 + 复制**按钮，仅对**地址固定的非咪咕频道**显示，并提示"复制出的是固定地址的独立频道、可在「外部源管理」删除"。
- **咪咕频道**地址为服务端跳转（`${replace}/pID`），暂不支持复制（前后端均拦）。

### 取舍
副本是地址的**静态快照**：适合地址不变的频道；对地址会轮换的源（部分抓取/订阅）副本不会跟着更新，UI 已提示。这是相对"虚拟多分组"更简单、且各分组天然独立的方案。

### 验证
守卫/转换逻辑（缺字段/咪咕拒绝、去重去空、safeLogo 仅 http）已独立验证；改动文件均过语法校验、无嵌入控制字节。

> 不含版本号变更——先合并进 main、暂不发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q)_