### PR TITLE
fix: 外部 EPG 配对走 display-name，修复「加了源一个都匹配不上」(issue #38)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
-    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs && node scripts/test-move-hide.mjs"
+    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs && node scripts/test-move-hide.mjs && node scripts/test-epg-match.mjs"
   },
   "dependencies": {
     "node-fetch": "^3.3.2",

--- a/scripts/test-epg-match.mjs
+++ b/scripts/test-epg-match.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * 外部 EPG 配对回归测试（issue #38）
+ *
+ * 核心不变量：XMLTV 的频道配对要走 <channel> 的 <display-name>，而不是只拿
+ * <programme channel="ID"> 的 id 归一——否则数字/不透明 id 的源会一个都配不上。
+ *
+ * 运行： node scripts/test-epg-match.mjs   （或 npm test）
+ */
+import assert from 'node:assert/strict'
+import { parseProgrammes, buildChannelKeyMap } from '../utils/epgParse.js'
+import { normalizeKey } from '../utils/channelNormalize.js'
+
+let passed = 0
+const check = (n, fn) => { fn(); passed++; console.log('  ✅ ' + n) }
+
+console.log('外部 EPG 配对回归测试 (issue #38)')
+
+// 1) 数字/不透明 id + display-name（旧实现拿 id 归一 → 0 命中，正是反馈的 bug）
+const xmlNumeric = `<?xml version="1.0"?>
+<tv>
+  <channel id="475"><display-name lang="zh">CCTV1综合</display-name></channel>
+  <channel id="476"><display-name>湖南卫视</display-name></channel>
+  <channel id="999"><display-name>不需要的台</display-name></channel>
+  <programme channel="475" start="1"><title>新闻联播</title></programme>
+  <programme channel="475" start="2"><title>焦点访谈</title></programme>
+  <programme channel="476" start="1"><title>歌手</title></programme>
+  <programme channel="999" start="1"><title>无关</title></programme>
+</tv>`
+
+check('数字 id + display-name：按 display-name 命中（多 programme 都收）', () => {
+  const wanted = new Set([normalizeKey('CCTV1综合'), normalizeKey('湖南卫视')])
+  const byKey = parseProgrammes(xmlNumeric, wanted)
+  assert.equal(byKey.get(normalizeKey('CCTV1综合'))?.length, 2)
+  assert.equal(byKey.get(normalizeKey('湖南卫视'))?.length, 1)
+  assert.equal(byKey.has(normalizeKey('不需要的台')), false) // 不在 wanted 不收
+  // 旧实现拿数字 id 归一：normalizeKey('475') 不等于任何 wanted key —— 证明旧 bug 的成因
+  assert.equal(wanted.has(normalizeKey('475')), false)
+})
+
+// 2) id 即频道名（兼容老路径）：仍能命中，且外部源异写法经 #39 归一也能对上
+const xmlNameId = `<tv>
+  <channel id="CCTV5体育"><display-name>CCTV5体育</display-name></channel>
+  <programme channel="CCTV5体育" start="1"><title>赛事</title></programme>
+</tv>`
+check('id 即频道名 + 外部异写法（CCTV-5）：仍命中', () => {
+  const wanted = new Set([normalizeKey('CCTV-5')]) // 归一后 = CCTV5
+  const byKey = parseProgrammes(xmlNameId, wanted)
+  assert.equal(byKey.get(normalizeKey('CCTV-5'))?.length, 1)
+})
+
+// 3) 无 <channel> 元素、只有 programme：退回 id 自身归一兜底
+const xmlNoChannel = `<tv>
+  <programme channel="CCTV1" start="1"><title>x</title></programme>
+</tv>`
+check('无 <channel> 时退回 id 自身归一', () => {
+  const wanted = new Set([normalizeKey('CCTV1综合')]) // CCTV1 与 CCTV1综合 归一同为 CCTV1
+  const byKey = parseProgrammes(xmlNoChannel, wanted)
+  assert.equal(byKey.get(normalizeKey('CCTV1综合'))?.length, 1)
+})
+
+// 4) 一个频道多个 <display-name> 别名都进映射
+const xmlAlias = `<tv>
+  <channel id="hunan"><display-name>湖南卫视HD</display-name><display-name>湖南卫视</display-name></channel>
+  <programme channel="hunan" start="1"><title>x</title></programme>
+</tv>`
+check('多 display-name 别名都建入映射', () => {
+  const map = buildChannelKeyMap(xmlAlias)
+  assert.ok(map.get('hunan').has(normalizeKey('湖南卫视')))
+})
+
+console.log(`\n全部通过：${passed}/4 ✅`)

--- a/utils/epgAggregator.js
+++ b/utils/epgAggregator.js
@@ -16,6 +16,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { appendFileSync, writeJsonFileSync } from './fileUtil.js'
 import { dataPath } from './paths.js'
 import { normalizeKey, normalizeTvgName } from './channelNormalize.js'
+import { parseProgrammes, rewriteChannel, escapeXml } from './epgParse.js'
 import { enableEpgAggregation, enableTvgNormalize } from '../config.js'
 import { printGreen, printRed, printYellow, printBlue } from './colorOut.js'
 
@@ -78,20 +79,6 @@ function saveEpgConfig(config) {
   }
 }
 
-// XML 实体反转义（配对前还原频道名里的 &amp; 等）
-function decodeXml(s) {
-  return s
-    .replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>')
-    .replaceAll('&quot;', '"').replaceAll('&apos;', "'")
-}
-
-// XML 实体转义（写出 channel id / display-name 时用）
-function escapeXml(s) {
-  return String(s)
-    .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;').replaceAll("'", '&apos;')
-}
-
 function ensureCacheDir() {
   try { mkdirSync(EPG_CACHE_DIR, { recursive: true }) } catch { /* 已存在或不可创建，后续读写自然报错 */ }
 }
@@ -151,32 +138,6 @@ async function ensureRawXml(source, cachePath) {
     printRed(`EPG 源「${source.name}」下载失败且无缓存，跳过: ${e.message}`)
     return false
   }
-}
-
-const PROG_RE = /<programme\b([^>]*)>[\s\S]*?<\/programme>/g
-const CH_ATTR_RE = /channel="([^"]*)"/
-
-// 从 XMLTV 文本中，按归一 key 收集 <programme> 块；只保留 wantedKeys 命中的频道，控制内存与体积。
-// 返回 Map<归一key, [programme 原始 XML 块, ...]>
-function parseProgrammes(xml, wantedKeys) {
-  const byKey = new Map()
-  PROG_RE.lastIndex = 0
-  let m
-  while ((m = PROG_RE.exec(xml)) !== null) {
-    const cm = CH_ATTR_RE.exec(m[1])
-    if (!cm) continue
-    const k = normalizeKey(decodeXml(cm[1]))
-    if (!k || !wantedKeys.has(k)) continue
-    let arr = byKey.get(k)
-    if (!arr) { arr = []; byKey.set(k, arr) }
-    arr.push(m[0])
-  }
-  return byKey
-}
-
-// 把 programme 块里的 channel 属性改写为合并后输出用的频道 id
-function rewriteChannel(block, outputId) {
-  return block.replace(CH_ATTR_RE, `channel="${escapeXml(outputId)}"`)
 }
 
 /**

--- a/utils/epgParse.js
+++ b/utils/epgParse.js
@@ -1,0 +1,89 @@
+// 外部 EPG（XMLTV）解析与频道配对（issue #38）
+//
+// 从 epgAggregator 拆出的纯解析逻辑：不依赖网络，便于单测，也把「下载」与「解析」职责分开。
+//
+// 关键修复（issue #38 反馈「加了很多源一个都匹配不上」）：
+//   XMLTV 里 <programme channel="ID"> 的 ID 是「频道 id」，现实中常是数字 / 拼音 / 不透明串，
+//   真正的频道名在 <channel id="ID"><display-name>名字</display-name></channel> 里。
+//   原实现直接拿 programme 的 channel 属性（= id）归一比对，遇到这类源永远 0 命中。
+//   现改为先建立 id → display-name 映射，用 display-name（并保留 id 本身）归一后比对。
+
+import { normalizeKey } from './channelNormalize.js'
+
+const PROG_RE = /<programme\b([^>]*)>[\s\S]*?<\/programme>/g
+const CH_ATTR_RE = /channel="([^"]*)"/
+const CHANNEL_RE = /<channel\b([^>]*)>([\s\S]*?)<\/channel>/g
+const ID_ATTR_RE = /id="([^"]*)"/
+const DISPLAY_NAME_RE = /<display-name\b[^>]*>([\s\S]*?)<\/display-name>/g
+
+// XML 实体反转义（配对前还原频道名里的 &amp; 等）
+export function decodeXml(s) {
+  return String(s)
+    .replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"').replaceAll('&apos;', "'")
+}
+
+// XML 实体转义（写出 channel id / display-name 时用）
+export function escapeXml(s) {
+  return String(s)
+    .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;').replaceAll("'", '&apos;')
+}
+
+// 解析 <channel> 元素，建立「EPG 频道 id → 归一 key 集合」映射。
+// key 集合 = 该频道每个 <display-name> 的归一 key + id 本身的归一 key（兼容「id 即频道名」的源）。
+export function buildChannelKeyMap(xml) {
+  const map = new Map()
+  CHANNEL_RE.lastIndex = 0
+  let m
+  while ((m = CHANNEL_RE.exec(xml)) !== null) {
+    const idm = ID_ATTR_RE.exec(m[1])
+    if (!idm) continue
+    const id = decodeXml(idm[1])
+    const keys = new Set()
+    const idKey = normalizeKey(id)
+    if (idKey) keys.add(idKey)
+    DISPLAY_NAME_RE.lastIndex = 0
+    let dn
+    while ((dn = DISPLAY_NAME_RE.exec(m[2])) !== null) {
+      const nk = normalizeKey(decodeXml(dn[1].trim()))
+      if (nk) keys.add(nk)
+    }
+    if (keys.size) map.set(id, keys)
+  }
+  return map
+}
+
+// 从 XMLTV 文本里，按归一 key 收集 <programme> 块；只保留 wantedKeys 命中的频道，控制内存与体积。
+// 通过 <channel> 的 display-name 把 programme 的 channel id 解析为归一 key（无对应 <channel> 时退回 id 自身归一）。
+// 返回 Map<归一key, [programme 原始 XML 块, ...]>
+export function parseProgrammes(xml, wantedKeys) {
+  const idKeyMap = buildChannelKeyMap(xml)
+  const byKey = new Map()
+  PROG_RE.lastIndex = 0
+  let m
+  while ((m = PROG_RE.exec(xml)) !== null) {
+    const cm = CH_ATTR_RE.exec(m[1])
+    if (!cm) continue
+    const chId = decodeXml(cm[1])
+    let keys = idKeyMap.get(chId)
+    if (!keys) {
+      const k = normalizeKey(chId)
+      if (!k) continue
+      keys = new Set([k])
+    }
+    for (const k of keys) {
+      if (!wantedKeys.has(k)) continue
+      let arr = byKey.get(k)
+      if (!arr) { arr = []; byKey.set(k, arr) }
+      arr.push(m[0])
+      break // 一个 programme 只归到一个目标频道，避免重复
+    }
+  }
+  return byKey
+}
+
+// 把 programme 块里的 channel 属性改写为合并后输出用的频道 id
+export function rewriteChannel(block, outputId) {
+  return block.replace(CH_ATTR_RE, `channel="${escapeXml(outputId)}"`)
+}


### PR DESCRIPTION
## 修复 issue #38：外部 EPG 聚合「加了很多源一个都匹配不上」

### 根因
`epgAggregator.parseProgrammes` 只拿 `<programme channel="ID">` 的 **ID（频道 id）** 归一去配对，**从不读 `<channel>` 的 `<display-name>`**。而 XMLTV 现实中 `channel` 属性常是**数字 / 拼音 / 不透明串**（真正频道名在 `<channel id="ID"><display-name>名字</display-name>` 里）。这类源里 `normalizeKey("475")` 永远配不上播放列表的 `CCTV1综合` → **全源 0 命中**，正是 lopelduo 反馈的现象。

### 修复
配对改为走 **display-name**：
- 新增 `utils/epgParse.js`（从 `epgAggregator` 拆出的**纯解析逻辑**，不依赖网络、便于单测，也把「下载」与「解析」分离）：
  - `buildChannelKeyMap`：先建「EPG 频道 id → 归一 key 集合」（含每个 `<display-name>` 的归一 key，**也保留 id 本身归一作兜底**，兼容「id 即频道名」的源）；
  - `parseProgrammes`：据此把 programme 的 channel id 解析成归一 key 再配对。
- `epgAggregator.js` 改为从 `epgParse` 引入解析函数，删除内联旧逻辑。**输出 id 不变**，仍与播放列表 tvg-id 取同一变换，播放器照常对上。

### 测试
新增 `scripts/test-epg-match.mjs`，`npm test` 全绿（6+10+7+4）。覆盖：数字 id+display-name 命中、id 即名兼容、无 `<channel>` 退回 id、多 display-name 别名。

> 注：真实第三方 EPG 源（51zmt:8000 / epg.pw / gitee）在本沙箱网络不可达，未能在线验证；以合成 XMLTV 单测覆盖两类 id 风格。建议合并后用真实源回归一次。
>
> 不含版本号变更——先合并进 main、暂不发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTExKJYaLgn4mrzFxF4K6Q)_