### PR TITLE
fix: #56 CCTV 4K/8K 归一独立，不再与 CCTV4/CCTV8 错误合并

### DIFF
--- a/scripts/test-channel-normalize.mjs
+++ b/scripts/test-channel-normalize.mjs
@@ -93,4 +93,30 @@ check('logoMatchName 清洗到公共库短名', () => {
   assert.equal(logoMatchName(''), '')
 })
 
+// 6) issue #56：CCTV 4K / 8K 超高清是独立频道，归一时不能和 CCTV4 / CCTV8 撞成同一台
+check('CCTV 4K/8K 与普通频道区分（issue #56）', () => {
+  // normalizeKey：4K/8K 各自独立的 key
+  assert.equal(normalizeKey('CCTV4K'), 'CCTV4K')
+  assert.equal(normalizeKey('CCTV-4K'), 'CCTV4K')
+  assert.equal(normalizeKey('CCTV4K超高清'), 'CCTV4K')
+  assert.equal(normalizeKey('CCTV-4k高码'), 'CCTV4K')
+  assert.equal(normalizeKey('cctv4k_10m'), 'CCTV4K')
+  assert.equal(normalizeKey('CCTV8K'), 'CCTV8K')
+  assert.equal(normalizeKey('CCTV-8K超高清[3840*2160]'), 'CCTV8K')
+  // 关键断言：4K/8K 不再与普通 CCTV4/CCTV8 同 key
+  assert.notEqual(normalizeKey('CCTV4'), normalizeKey('CCTV4K'))
+  assert.notEqual(normalizeKey('CCTV8'), normalizeKey('CCTV8K'))
+  // 普通 CCTV4/CCTV8 不受影响
+  assert.equal(normalizeKey('CCTV4'), 'CCTV4')
+  assert.equal(normalizeKey('CCTV-4中文国际'), 'CCTV4')
+  assert.equal(normalizeKey('CCTV8电视剧'), 'CCTV8')
+  // CCTV5+ / CCTV4欧美 不被误判（K 捕获不影响 +、欧、美）
+  assert.equal(normalizeKey('CCTV5+体育赛事'), 'CCTV5+')
+  assert.equal(normalizeKey('CCTV4欧洲'), 'CCTV4欧')
+  // logoMatchName 同步区分
+  assert.equal(logoMatchName('CCTV4K超高清'), 'CCTV4K')
+  assert.equal(logoMatchName('CCTV-8K超高清'), 'CCTV8K')
+  assert.notEqual(logoMatchName('CCTV4'), logoMatchName('CCTV4K'))
+})
+
 console.log(`\n全部通过：${passed} 组 ✅`)

--- a/utils/channelNormalize.js
+++ b/utils/channelNormalize.js
@@ -45,10 +45,12 @@ export function normalizeKey(name) {
   if (!name) return ""
   let s = yangshiToCctv(toHalfWidth(String(name)).trim().toUpperCase())
 
-  // CCTV 专项：靠频道号识别，丢弃「综合/财经/高清」等描述词，避免同台不同写法对不上
-  const m = s.match(/CCTV[-\s]*(\d{1,2})\s*(\+|PLUS|加)?/)
+  // CCTV 专项：靠频道号识别，丢弃「综合/财经/高清」等描述词，避免同台不同写法对不上。
+  // 数字后紧跟的 K（CCTV4K / CCTV8K 超高清）是独立频道，必须纳入 key，否则会和 CCTV4 / CCTV8 撞成同一台（issue #56）。
+  const m = s.match(/CCTV[-\s]*(\d{1,2})(K)?\s*(\+|PLUS|加)?/)
   if (m) {
-    let key = "CCTV" + m[1] + (m[2] ? "+" : "")
+    if (m[2]) return "CCTV" + m[1] + "K"   // 4K / 8K 超高清，与普通 CCTVn 区分
+    let key = "CCTV" + m[1] + (m[3] ? "+" : "")
     // CCTV4 有 中文国际 / 欧洲 / 美洲 三路，需区分，否则会互相覆盖
     if (/欧洲|欧/.test(s)) key += "欧"
     else if (/美洲|美/.test(s)) key += "美"
@@ -170,14 +172,15 @@ export function logoMatchName(name) {
   if (!name) return ''
   // 先把「央视N套」等中文写法转成 CCTVN，与 normalizeKey 同口径（fanmingming 只有 CCTV1.png，没有 央视1套.png）
   const raw = yangshiToCctv(toHalfWidth(String(name)).trim())
-  // CCTV：按频道号收敛到公共库短名（保留 + 与 CCTV4 的 欧洲/美洲 三路区分）
-  const cc = raw.toUpperCase().match(/CCTV[-\s]*(\d{1,2})\s*(\+|PLUS|加)?/)
+  // CCTV：按频道号收敛到公共库短名（保留 + 与 CCTV4 的 欧洲/美洲 三路区分；4K/8K 超高清独立，不并入 CCTVn）（issue #56）
+  const cc = raw.toUpperCase().match(/CCTV[-\s]*(\d{1,2})(K)?\s*(\+|PLUS|加)?/)
   if (cc) {
+    if (cc[2]) return 'CCTV' + cc[1] + 'K'   // CCTV4K / CCTV8K 超高清
     if (cc[1] === '4') {
       if (/欧/.test(raw)) return 'CCTV4欧洲'
       if (/美/.test(raw)) return 'CCTV4美洲'
     }
-    return 'CCTV' + cc[1] + (cc[2] ? '+' : '')
+    return 'CCTV' + cc[1] + (cc[3] ? '+' : '')
   }
   // 非 CCTV：去清晰度/运营商标注 → 清掉被掏空的空括号 → 去首尾分隔符（大小写与其余字符原样保留）
   let s = raw.replace(QUALITY, '').replace(OPERATOR, '')


### PR DESCRIPTION
## 背景（issue #56）

@dejavu9950 给 `CCTV-4` / `CCTV-4K` / `CCTV-8` / `CCTV-8K` 都配了别名规则，结果**所有 CCTV-4 被并进 CCTV-4K、CCTV-8 被并进 CCTV-8K**。

## 根因

`normalizeKey` / `logoMatchName` 的 CCTV 正则 `/CCTV[-\s]*(\d{1,2})…/` 只抓频道号、**丢掉后面的 K**：

| 输入 | 修复前 | 修复后 |
|---|---|---|
| `CCTV4` / `CCTV-4` | `CCTV4` | `CCTV4` |
| `CCTV4K` / `CCTV-4K超高清` | `CCTV4` ❌ 撞 | `CCTV4K` ✅ |
| `CCTV8K` | `CCTV8` ❌ 撞 | `CCTV8K` ✅ |

`CCTV4K` 和 `CCTV4` 算出同一个 key，用户给两者都配别名时（用户别名后者覆盖），key 最终指向 `CCTV-4K` → 所有 CCTV4/CCTV4K 全并进去。`CCTV-4K`/`CCTV-8K` 是独立超高清频道，不该和 CCTV-4/CCTV-8 合并。

## 改动

把数字后紧跟的 `K`（4K/8K 超高清）纳入 key：`CCTV4K → "CCTV4K"`、`CCTV4 → "CCTV4"`，两者独立；`+` / `欧` / `美` 等既有逻辑不受影响。`normalizeKey`（EPG/统一显示名）和 `logoMatchName`（台标）都修。

## 影响面

不只别名——内置「统一显示名」也一样：任何同时有 CCTV4 和 CCTV4K（或 8/8K）的用户都会被错误合并，本修复一并解决。

## 验证

`npm test` 全绿（新增 4K/8K 区分用例；现有 CCTV4中文国际/欧美/CCTV5+ 等用例不受影响）。

Closes #56 的该 bug（其余编辑别名/布局等诉求另行评估）

🤖 Generated with [Claude Code](https://claude.com/claude-code)