### PR TITLE
feat: #62 后续——配对状态点/图例 + 详情设别名 + 大logo + 公网地址 + 繁简归一

### DIFF
--- a/scripts/test-channel-normalize.mjs
+++ b/scripts/test-channel-normalize.mjs
@@ -119,4 +119,16 @@ check('CCTV 4K/8K 与普通频道区分（issue #56）', () => {
   assert.notEqual(logoMatchName('CCTV4'), logoMatchName('CCTV4K'))
 })
 
+// 7) issue #62：繁体频道名归一时转简体，能对上简体规范名
+check('繁体 → 简体 归一（issue #62）', () => {
+  assert.equal(normalizeKey('鳳凰衛視'), normalizeKey('凤凰卫视'))
+  assert.equal(normalizeKey('東森綜合台'), normalizeKey('东森综合台'))
+  assert.equal(normalizeKey('緯來體育'), normalizeKey('纬来体育'))
+  assert.equal(normalizeKey('中天新聞'), normalizeKey('中天新闻'))
+  assert.equal(normalizeKey('電視劇場'), normalizeKey('电视剧场'))
+  assert.equal(normalizeTvgName('CCTV1綜合'), 'CCTV1综合')   // 繁体也能命中 CCTV 规范名
+  assert.equal(logoMatchName('鳳凰衛視'), logoMatchName('凤凰卫视'))
+  assert.equal(logoMatchName('體育'), '体育')                // 台标匹配名也转简体
+})
+
 console.log(`\n全部通过：${passed} 组 ✅`)

--- a/utils/channelNormalize.js
+++ b/utils/channelNormalize.js
@@ -30,6 +30,27 @@ function toHalfWidth(s) {
     .replace(/　/g, " ")
 }
 
+// 繁体 → 简体（常用频道名字符表，轻量；让繁体 EPG / 源频道名也能对上简体规范名）。issue #62
+// 只取电视频道名里高频出现的字，不做全量 OpenCC（保持轻量）；只影响匹配 key，不改频道显示名。
+const T2S = {
+  '衛': '卫', '視': '视', '體': '体', '綜': '综', '電': '电', '劇': '剧', '場': '场', '鳳': '凤',
+  '際': '际', '國': '国', '頻': '频', '聞': '闻', '財': '财', '經': '经', '軍': '军', '農': '农',
+  '紀': '纪', '錄': '录', '藝': '艺', '臺': '台', '華': '华', '廣': '广', '東': '东', '語': '语',
+  '樂': '乐', '戲': '戏', '龍': '龙', '兒': '儿', '風': '风', '雲': '云', '緯': '纬', '來': '来',
+  '傳': '传', '統': '统', '醫': '医', '療': '疗', '釣': '钓', '魚': '鱼', '灣': '湾', '慶': '庆',
+  '寧': '宁', '號': '号', '線': '线', '聲': '声', '點': '点', '響': '响', '業': '业', '產': '产',
+  '護': '护', '後': '后', '將': '将', '馬': '马', '鳥': '鸟', '寶': '宝', '萬': '万', '與': '与',
+  '開': '开', '關': '关', '觀': '观', '區': '区', '縣': '县', '麗': '丽', '陸': '陆', '葉': '叶',
+  '雙': '双', '豐': '丰', '頭': '头', '陽': '阳', '義': '义', '術': '术', '畫': '画', '學': '学',
+  '時': '时', '間': '间', '實': '实', '現': '现', '當': '当', '發': '发', '愛': '爱', '歡': '欢',
+  '兩': '两', '個': '个', '靈': '灵', '嶺': '岭', '輪': '轮', '轉': '转', '遊': '游', '橋': '桥',
+}
+function toSimplified(s) {
+  let out = ''
+  for (const ch of s) out += (T2S[ch] || ch)
+  return out
+}
+
 // 「央视N / 央视N套 / 央视N台」→ CCTVN（含中文数字一~十七），与 CCTV 各种写法归一。
 // normalizeKey 与 logoMatchName 共用，保证两边对央视写法的口径一致（issue #40）。
 const CN_NUM = { '一': 1, '二': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9, '十': 10, '十一': 11, '十二': 12, '十三': 13, '十四': 14, '十五': 15, '十六': 16, '十七': 17 }
@@ -43,7 +64,7 @@ function yangshiToCctv(s) {
 // 把频道名归一成可比较的 key：CCTV 用频道号(及 +/欧美)做 key，其余去清晰度后缀和分隔符
 export function normalizeKey(name) {
   if (!name) return ""
-  let s = yangshiToCctv(toHalfWidth(String(name)).trim().toUpperCase())
+  let s = yangshiToCctv(toSimplified(toHalfWidth(String(name)).trim().toUpperCase()))
 
   // CCTV 专项：靠频道号识别，丢弃「综合/财经/高清」等描述词，避免同台不同写法对不上。
   // 数字后紧跟的 K（CCTV4K / CCTV8K 超高清）是独立频道，必须纳入 key，否则会和 CCTV4 / CCTV8 撞成同一台（issue #56）。
@@ -170,8 +191,8 @@ export function getPlaybackChannelIds() {
 // 让「CCTV1高清（电信）」「湖南卫视（电信）」这类特殊命名的常见频道也能命中公共库；频道显示名保持不变。
 export function logoMatchName(name) {
   if (!name) return ''
-  // 先把「央视N套」等中文写法转成 CCTVN，与 normalizeKey 同口径（fanmingming 只有 CCTV1.png，没有 央视1套.png）
-  const raw = yangshiToCctv(toHalfWidth(String(name)).trim())
+  // 先把「央视N套」等中文写法转成 CCTVN，与 normalizeKey 同口径（fanmingming 只有 CCTV1.png，没有 央视1套.png）；繁体转简体（issue #62）
+  const raw = yangshiToCctv(toSimplified(toHalfWidth(String(name)).trim()))
   // CCTV：按频道号收敛到公共库短名（保留 + 与 CCTV4 的 欧洲/美洲 三路区分；4K/8K 超高清独立，不并入 CCTVn）（issue #56）
   const cc = raw.toUpperCase().match(/CCTV[-\s]*(\d{1,2})(K)?\s*(\+|PLUS|加)?/)
   if (cc) {

--- a/web/admin.html
+++ b/web/admin.html
@@ -2650,6 +2650,7 @@
                 }
                 systemConfig = await systemRes.json();
                 console.log('系统配置加载成功');
+                renderSubscribeBar();  // 配置加载后重渲染订阅栏，让「公网地址」按钮按 mhost 出现（issue #62）
 
                 // 加载 EPG 聚合源配置（issue #38）；失败不影响其余加载
                 loadEpgSources();
@@ -4207,13 +4208,24 @@ if(success){
             const q = (activeProfile && activeProfile !== 'default') ? ('?profile=' + encodeURIComponent(activeProfile)) : '';
             const m3u = base + '/interface.m3u' + q;
             const epg = base + '/playback.xml';
-            bar.innerHTML =
+            let html =
                 `<span class="sb-label">📡 订阅地址</span>`
                 + `<code title="${escapeHtml(m3u)}">${escapeHtml(m3u)}</code>`
                 + `<button class="sb-copy" onclick="copyToClipboard('${m3u.replace(/'/g, "\\'")}', '订阅地址')">📋 复制</button>`
                 + `<span class="sb-sep">节目单 EPG</span>`
                 + `<code class="sb-epg" title="${escapeHtml(epg)}">${escapeHtml(epg)}</code>`
                 + `<button class="sb-copy sb-copy-muted" onclick="copyToClipboard('${epg.replace(/'/g, "\\'")}', 'EPG 地址')">📋 复制</button>`;
+            // 公网地址（系统配置里的「公网地址」mhost）：给别人用时复制公网版，免得复制出内网 IP 还要手动替换（issue #62）
+            const cfgHost = (systemConfig && (systemConfig.host || (systemConfig.data && systemConfig.data.host))) || '';
+            if (cfgHost) {
+                const pub = String(cfgHost).replace(/\/+$/, '') + API_PREFIX;
+                const pubM3u = pub + '/interface.m3u' + q;
+                const pubEpg = pub + '/playback.xml';
+                html += `<span class="sb-sep" title="来自「系统配置 → 公网地址」，分享给外网用户用这个">🌐 公网</span>`
+                    + `<button class="sb-copy" onclick="copyToClipboard('${pubM3u.replace(/'/g, "\\'")}', '公网订阅地址')" title="${escapeHtml(pubM3u)}">📋 复制公网订阅</button>`
+                    + `<button class="sb-copy sb-copy-muted" onclick="copyToClipboard('${pubEpg.replace(/'/g, "\\'")}', '公网 EPG 地址')" title="${escapeHtml(pubEpg)}">📋 公网 EPG</button>`;
+            }
+            bar.innerHTML = html;
         }
 
         // 频道列表「配对状态」双圆点（issue #62）：左=节目单(epgMatched) 右=台标。

--- a/web/admin.html
+++ b/web/admin.html
@@ -2581,6 +2581,33 @@
             else showStatus(r.message || '删除失败', 'error');
         }
 
+        // 在「频道详情」里直接给本频道设别名（issue #62）：把本频道名追加到指定规范名下（不覆盖已有别名），
+        // 保存后重新加载「我的频道」即时重算配对状态（别名即时进 getCanonicalMap）。
+        async function setAliasFromDetail() {
+            const el = document.getElementById('detailAliasCanonical');
+            const canonical = el ? el.value.trim() : '';
+            if (!canonical) { showStatus('请填写规范名', 'error'); return; }
+            if (!currentChannelDetail) return;
+            const alias = (currentChannelDetail.tvgName || currentChannelDetail.name || '').trim();
+            if (!alias) { showStatus('该频道无可用名称', 'error'); return; }
+            // 取该规范名现有别名，合并追加（不覆盖）
+            let existing = [];
+            try {
+                const res = await fetch(API_PREFIX + '/api/channel-aliases');
+                const p = await res.json();
+                if (p && p.success && p.data && Array.isArray(p.data[canonical])) existing = p.data[canonical];
+            } catch (e) { /* 取不到就按空处理 */ }
+            const merged = [...new Set([...existing, alias])];
+            const r = await aliasesPost({ action: 'setRule', canonical, aliases: merged });
+            if (r.success) {
+                aliasesData = r.data;
+                showStatus(`已设别名「${alias}」→「${canonical}」，正在刷新配对状态…`, 'success');
+                try { await loadMyPlaylist(false); } catch (e) { /* 刷新失败不影响别名已保存 */ }
+            } else {
+                showStatus(r.message || '保存别名失败', 'error');
+            }
+        }
+
         // 加载数据
         async function loadData() {
             try {
@@ -5553,6 +5580,17 @@ if(success){
                         ${(channel.epgName && channel.epgName !== channel.name)
                             ? `<div style="color:#999;font-size:12px;margin-top:6px;line-height:1.6;">显示名「${channel.name}」已自动归一到「${channel.epgName}」匹配节目单，显示名本身不变。</div>`
                             : ''}
+                        ${!channel.epgMatched
+                            ? `<div style="margin-top:8px;padding:8px 10px;background:#fffbe6;border:1px solid #ffe58f;border-radius:4px;">
+                                <div style="font-size:12px;color:#8a5a00;margin-bottom:6px;">节目单没匹配上？给它设个<strong>别名</strong>归一到正确的频道名（保存后刷新播放列表生效，不用去配置页）：</div>
+                                <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+                                    <span style="font-size:12px;color:#888;flex:0 0 auto;">规范名</span>
+                                    <input id="detailAliasCanonical" type="text" placeholder="统一后的频道名，如 CCTV5体育" style="flex:1;min-width:150px;padding:4px 8px;border:1px solid #ddd;border-radius:4px;font-size:13px;">
+                                    <button class="btn btn-sm btn-primary" onclick="setAliasFromDetail()">保存别名</button>
+                                </div>
+                                <div style="font-size:11px;color:#aaa;margin-top:5px;">别名 = 本频道名「${channel.tvgName || channel.name}」，追加到该规范名下（不覆盖已有别名）</div>
+                            </div>`
+                            : ''}
                     </div>
             `;
 
@@ -5655,7 +5693,7 @@ if(success){
                     <div style="margin-bottom: 15px;">
                         <strong style="color: #667eea;">台标：</strong>
                         <div style="display:flex; align-items:center; gap:10px; margin-top:6px;">
-                            <img id="channelLogoPreview" src="${_logoSrc}" alt="" style="width:48px;height:48px;object-fit:contain;border:1px solid #eee;border-radius:6px;background:#fafafa;${_logoSrc ? '' : 'display:none;'}" onerror="this.style.display='none';var e=document.getElementById('channelLogoEmpty');if(e)e.style.display='';">
+                            <img id="channelLogoPreview" src="${_logoSrc}" alt="" style="width:120px;height:120px;object-fit:contain;border:1px solid #eee;border-radius:8px;background:#fafafa;padding:6px;${_logoSrc ? '' : 'display:none;'}" onerror="this.style.display='none';var e=document.getElementById('channelLogoEmpty');if(e)e.style.display='';">
                             <span id="channelLogoEmpty" style="color:#999;font-size:12px;${_logoSrc ? 'display:none;' : ''}">暂无台标</span>
                             <input type="file" accept="image/png,image/jpeg,image/webp" onchange="uploadCurrentChannelLogo(this)">
                             <button class="btn btn-sm btn-danger" onclick="removeCurrentChannelLogo()">移除</button>

--- a/web/admin.html
+++ b/web/admin.html
@@ -1629,11 +1629,21 @@
             background: #f5f5f5;
         }
 
-        /* 频道台标缩略图（issue #38）。不加背景框，非方形图也自然显示；无台标则整块不显示（issue #62）。
-           节目单配对状态不放进列表（无文字说明不易懂），改在「频道详情」里以文字展示（issue #62）。 */
-        .ch-logo-wrap { flex: 0 0 auto; margin-right: 8px; display: inline-flex; }
-        .ch-logo { width: 26px; height: 26px; object-fit: contain; }
-        .ch-logo-ph { width: 26px; height: 26px; display: inline-block; }   /* 无台标：同尺寸透明空白占位，保持频道名对齐（issue #62） */
+        /* 频道列表「配对状态」双圆点（issue #62）：左=节目单 右=台标，绿=已匹配 红=未匹配。
+           常驻图例（下方 .ch-status-legend）说明含义，避免「光放图标看不懂」。 */
+        .ch-status { flex: 0 0 auto; margin-right: 9px; display: inline-flex; gap: 4px; align-items: center; }
+        .ch-status .dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
+        .dot.ok { background: #3cb95a; }
+        .dot.no { background: #f0676a; }
+        /* 配对状态图例：常驻在频道列表上方 */
+        .ch-status-legend {
+            display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+            font-size: 12px; color: #8a8a8a; background: #fafafa;
+            border: 1px solid #f0f0f0; border-radius: 6px; padding: 6px 12px; margin-bottom: 10px;
+        }
+        .ch-status-legend b { color: #666; font-weight: 500; }
+        .ch-status-legend .seg { display: inline-flex; align-items: center; gap: 5px; }
+        .ch-status-legend .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
 
         /* 顶部内联订阅地址栏（issue #38：免点编辑即可复制） */
         .subscribe-bar {
@@ -1860,6 +1870,12 @@
                         <div class="my-playlist-detail-header" id="detailHeader" style="display: none;">
                             <div class="my-playlist-detail-title" id="detailTitle"></div>
                             <div class="my-playlist-detail-actions" id="detailActions"></div>
+                        </div>
+                        <div class="ch-status-legend">
+                            <b>配对状态</b>
+                            <span class="seg"><span class="dot ok"></span><span class="dot ok"></span> 左=节目单　右=台标</span>
+                            <span class="seg"><span class="dot ok"></span> 绿 已匹配</span>
+                            <span class="seg"><span class="dot no"></span> 红 未匹配（点开频道详情可设别名修正）</span>
                         </div>
                         <div class="my-playlist-groups" id="myPlaylistGroups"></div>
                     </div>
@@ -4173,17 +4189,28 @@ if(success){
                 + `<button class="sb-copy sb-copy-muted" onclick="copyToClipboard('${epg.replace(/'/g, "\\'")}', 'EPG 地址')">📋 复制</button>`;
         }
 
-        // 频道台标缩略图（issue #38）：有台标才显示；无台标 / 加载失败则什么都不显示（issue #62）。仅展示，点击仍走频道名。
-        function channelLogoThumb(channel) {
+        // 频道列表「配对状态」双圆点（issue #62）：左=节目单(epgMatched) 右=台标。
+        // 台标点用真实图片加载结果判定（绿=能加载到 / 红=加载失败或无图），比单看 logoStatus 更准。
+        // 含义由上方常驻图例 + 每点 hover 文字说明；详情里仍有完整文字。
+        function channelStatusDots(channel) {
             const base = window.location.origin + API_PREFIX;
             const src = channel.logo ? String(channel.logo).replace(/\$\{replace\}/g, base) : '';
-            // 无台标 / 加载失败：保留同尺寸透明空白占位（无背景），让有/无台标的频道名对齐（issue #62）
-            if (!src) return `<span class="ch-logo-wrap" aria-hidden="true"><span class="ch-logo-ph"></span></span>`;
-            const tip = { local: '台标：本地上传', source: '台标：源自带', auto: '台标：公共库匹配' }[channel.logoStatus] || '台标';
-            return `<span class="ch-logo-wrap" aria-hidden="true">`
-                + `<img class="ch-logo" src="${escapeHtml(src)}" loading="lazy" alt="" title="${escapeHtml(tip)}" `
-                + `onerror="this.style.display='none';this.nextElementSibling.style.display='inline-block'">`
-                + `<span class="ch-logo-ph" style="display:none"></span></span>`;
+            const epgOk = !!channel.epgMatched;
+            const epgTip = epgOk ? ('节目单：已匹配' + (channel.epgName ? ' · ' + channel.epgName : '')) : '节目单：未匹配';
+            const logoTip = '台标：' + ({ local: '本地上传', source: '源自带', auto: '公共库', none: '无' }[channel.logoStatus] || '未知');
+            let logoDot;
+            if (src) {
+                // 先按已匹配渲染绿点，再用隐藏 img 实测；加载失败则把点转红
+                logoDot = `<span class="dot ok" title="${escapeHtml(logoTip)}"></span>`
+                    + `<img src="${escapeHtml(src)}" alt="" loading="lazy" style="display:none" `
+                    + `onload="this.remove()" onerror="this.previousElementSibling.className='dot no';this.previousElementSibling.title='台标：未匹配';this.remove()">`;
+            } else {
+                logoDot = `<span class="dot no" title="台标：无"></span>`;
+            }
+            return `<span class="ch-status" aria-hidden="true">`
+                + `<span class="dot ${epgOk ? 'ok' : 'no'}" title="${escapeHtml(epgTip)}"></span>`
+                + logoDot
+                + `</span>`;
         }
 
         function renderMyPlaylist() {
@@ -4397,7 +4424,7 @@ if(success){
                                            onchange="toggleChannelSelection('${channel.id}')"
                                            ${selectedChannels.has(channel.id) ? 'checked' : ''}>
                                 ` : ''}
-                                ${channelLogoThumb(channel)}
+                                ${channelStatusDots(channel)}
                                 <div class="my-playlist-channel-name" title="点击查看详情：${channel.name}" onclick="showChannelDetail('${channel.id}', true)" style="cursor: pointer;">
                                     <span class="channel-detail-hint" aria-hidden="true">ⓘ</span>${channel.name}
                                 </div>
@@ -4468,7 +4495,7 @@ if(success){
                                                onchange="toggleChannelSelection('${channel.id}')"
                                                ${selectedChannels.has(channel.id) ? 'checked' : ''}>
                                     ` : (isNameSorted ? `<span class="channel-drag-handle" aria-hidden="true"></span>` : `<span class="channel-drag-handle" aria-hidden="true" title="拖拽排序">⠿</span>`)}
-                                    ${channelLogoThumb(channel)}
+                                    ${channelStatusDots(channel)}
                                     <div class="my-playlist-channel-name" title="点击查看详情：${channel.name}" onclick="showChannelDetail('${channel.id}', false)" style="cursor: pointer;">
                                         <span class="channel-detail-hint" aria-hidden="true">ⓘ</span>${channel.name}
                                     </div>


### PR DESCRIPTION
承接 issue #62 LIUBANGJIAN 的一批反馈（4K/8K 错配已在 #63 单独修复）。

## 改动（5 项，逐条对应他的建议）

1. **列表配对状态双圆点 + 常驻图例**（他的 #1）：把台标缩略图换成两个小圆点（左=节目单 右=台标，绿=已匹配/红=未匹配；台标点用真实图片加载结果判定更准），上方加常驻图例 + 每点 hover 文字 + 详情仍有完整文字——补上「光放图标看不懂」的短板。
2. **频道详情里直接设别名**（他的 #2）：节目单未匹配时，详情里直接填规范名给本频道设别名（追加到该规范名下、不覆盖已有），保存后即时重算配对状态，不用去配置页。
3. **详情台标放大**（他的 #3）：48px → 120px。
4. **订阅地址栏支持复制公网地址**（他的 #5）：系统配置「公网地址」(mhost) 设置后，订阅栏新增「复制公网订阅 / 公网 EPG」，分享公网 URL 后外网用户拉取时 x-tvg-url 也会是公网地址。
5. **EPG/台标归一支持繁体转简体**（他的 #6）：normalizeKey/logoMatchName 匹配前用常用频道名字符表做繁→简（轻量），繁体源也能对上简体规范名。

> 他的 #4「为什么是未分组」非 bug——订阅 m3u 没写 group-title 所致，回复里解释。

## 验证

`npm test` 全绿（新增繁简用例）；admin.html 脚本语法校验通过；状态点/图例设计经预览确认观感。

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)