### PR TITLE
feat: #69 关键字自动分组（未分组频道按频道名关键字自动归类）

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ import { getEpgSourcesAPI, setEpgEnabledAPI, addEpgSourceAPI, updateEpgSourceAPI
 import { userManager } from "./utils/userManager.js";
 import { getUsersAPI, addUserAPI, updateUserAPI, removeUserAPI, regenUserTokenAPI, setRequireTokenAPI } from "./utils/usersAPI.js";
 import { getAliasesAPI, setAliasRuleAPI, removeAliasRuleAPI } from "./utils/aliasesAPI.js";
+import { getGroupRulesAPI, setGroupRuleAPI, removeGroupRuleAPI } from "./utils/groupRulesAPI.js";
 import { getSystemConfigAPI, saveSystemConfigAPI } from "./utils/systemConfigAPI.js";
 import { readConfig, saveConfig, parseInterfaceTxt, validateGroupConfig, applyConfig,
          listProfiles, createProfile, renameProfile, deleteProfile } from "./utils/playlistConfig.js";
@@ -335,6 +336,32 @@ const server = http.createServer(async (req, res) => {
         switch (data.action) {
           case 'setRule': result = setAliasRuleAPI(data.canonical, data.aliases); break
           case 'removeRule': result = removeAliasRuleAPI(data.canonical); break
+          default: result = { success: false, message: '未知操作' }
+        }
+        res.writeHead(result.success ? 200 : 500, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify(result));
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json;charset=UTF-8' });
+        res.end(JSON.stringify({ success: false, message: error.message }));
+      }
+      return
+    }
+
+    // 关键字自动分组规则（issue #69）
+    if (routePath === '/api/group-keyword-rules' && method === 'GET') {
+      const result = getGroupRulesAPI()
+      res.writeHead(result.success ? 200 : 500, { 'Content-Type': 'application/json;charset=UTF-8' });
+      res.end(JSON.stringify(result));
+      return
+    }
+
+    if (routePath === '/api/group-keyword-rules' && method === 'POST') {
+      try {
+        const data = JSON.parse(await readBody(req))
+        let result
+        switch (data.action) {
+          case 'setRule': result = setGroupRuleAPI(data.group, data.keywords); break
+          case 'removeRule': result = removeGroupRuleAPI(data.group); break
           default: result = { success: false, message: '未知操作' }
         }
         res.writeHead(result.success ? 200 : 500, { 'Content-Type': 'application/json;charset=UTF-8' });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
-    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs && node scripts/test-move-hide.mjs && node scripts/test-epg-match.mjs"
+    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs && node scripts/test-move-hide.mjs && node scripts/test-epg-match.mjs && node scripts/test-group-keyword.mjs"
   },
   "dependencies": {
     "node-fetch": "^3.3.2",

--- a/scripts/test-group-keyword.mjs
+++ b/scripts/test-group-keyword.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * 关键字自动分组回归测试（issue #69）
+ *
+ * 不变量：
+ *  1) matchGroupByRules —— 子串包含、大小写不敏感、首条命中胜、空关键字/空分组名不误命中。
+ *  2) applyConfig —— 关键字规则「只对未分组生效」：源已分好的分组不动；单频道手动移动优先级
+ *     高于关键字；未命中的频道留在「未分组」。
+ *
+ * 运行： node scripts/test-group-keyword.mjs   （或 npm test）
+ */
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { matchGroupByRules } from '../utils/groupRulesAPI.js'
+import { applyConfig } from '../utils/playlistConfig.js'
+import { dataPath } from '../utils/paths.js'
+
+for (const k of ['log', 'info', 'warn']) {
+  const orig = console[k]
+  console[k] = (...a) => { if (a.some(x => typeof x === 'string' && /应用播放列表配置|配置应用完成/.test(x))) return; orig.apply(console, a) }
+}
+
+let passed = 0
+const check = (name, fn) => { fn(); passed++; console.log(`  ✅ ${name}`) }
+
+console.log('关键字自动分组回归测试 (issue #69)')
+
+// 1) 纯匹配逻辑（无 I/O）
+const RULES = [
+  { group: '央视', keywords: ['CCTV', '央视'] },
+  { group: '卫视', keywords: ['卫视'] },
+  { group: '影视', keywords: ['电影', '影院', '电视剧'] },
+]
+check('matchGroupByRules：子串 / 大小写 / 无命中', () => {
+  assert.equal(matchGroupByRules('CCTV1高清', RULES), '央视')
+  assert.equal(matchGroupByRules('cctv5体育', RULES), '央视')        // 大小写不敏感
+  assert.equal(matchGroupByRules('央视新闻', RULES), '央视')
+  assert.equal(matchGroupByRules('湖南卫视', RULES), '卫视')
+  assert.equal(matchGroupByRules('HBO电影', RULES), '影视')
+  assert.equal(matchGroupByRules('凤凰中文', RULES), null)           // 无命中
+  assert.equal(matchGroupByRules('', RULES), null)
+})
+check('matchGroupByRules：首条命中胜（顺序敏感）', () => {
+  const r1 = [{ group: '体育', keywords: ['CCTV5'] }, { group: '央视', keywords: ['CCTV'] }]
+  assert.equal(matchGroupByRules('CCTV5体育', r1), '体育')           // 第一条先命中
+  const r2 = [{ group: '央视', keywords: ['CCTV'] }, { group: '体育', keywords: ['CCTV5'] }]
+  assert.equal(matchGroupByRules('CCTV5体育', r2), '央视')           // 顺序反过来 → 第一条命中
+})
+check('matchGroupByRules：空关键字 / 空分组名不误命中', () => {
+  assert.equal(matchGroupByRules('任意频道', [{ group: 'X', keywords: [''] }]), null)
+  assert.equal(matchGroupByRules('任意频道', [{ group: '', keywords: ['任意'] }]), null)
+})
+
+// 2) applyConfig 集成（写临时规则文件，测完还原；getKeywordGroupRules 按 mtime 缓存，写后即新）
+const RP = dataPath('group-keyword-rules.json')
+const backup = existsSync(RP) ? readFileSync(RP) : null
+try {
+  writeFileSync(RP, JSON.stringify(RULES))
+  const groups = () => ([
+    { name: '未分组', channels: [
+      { id: 'a1', name: 'CCTV1高清' },
+      { id: 'a2', name: '湖南卫视' },
+      { id: 'a3', name: '某独立台' },
+    ] },
+    { name: '体育', channels: [{ id: 'b1', name: 'CCTV5体育' }] },
+  ])
+  const grpOf = (cfg, ch) => applyConfig(groups(), cfg).find(g => g.channels.some(c => c.name === ch))?.name
+
+  check('未分组频道按关键字归位（CCTV1高清→央视、湖南卫视→卫视）', () => {
+    assert.equal(grpOf({}, 'CCTV1高清'), '央视')
+    assert.equal(grpOf({}, '湖南卫视'), '卫视')
+  })
+  check('未命中的频道留在「未分组」', () => {
+    assert.equal(grpOf({}, '某独立台'), '未分组')
+  })
+  check('源已分好组的频道不被关键字改动（CCTV5体育 留在 体育，不进 央视）', () => {
+    assert.equal(grpOf({}, 'CCTV5体育'), '体育')
+  })
+  check('单频道手动移动优先级高于关键字（a1→我的最爱）', () => {
+    assert.equal(grpOf({ channelGroupMap: { '未分组::a1': '我的最爱' } }, 'CCTV1高清'), '我的最爱')
+  })
+} finally {
+  if (backup) writeFileSync(RP, backup)
+  else if (existsSync(RP)) unlinkSync(RP)
+}
+
+console.log(`\n全部通过：${passed}/7 ✅`)

--- a/utils/groupRulesAPI.js
+++ b/utils/groupRulesAPI.js
@@ -1,0 +1,103 @@
+// 关键字自动分组规则 API（issue #69）—— 可视化维护 data/group-keyword-rules.json
+//
+// 格式（数组，保留顺序以支持「首条命中胜」）：
+//   [{ "group": "央视", "keywords": ["CCTV", "央视"] }, { "group": "影视", "keywords": ["电影","影院","电视剧"] }, ...]
+//
+// 用途：自定义订阅源里没写分组(group-title)的频道会落到「未分组」，且每次刷新新频道又回到未分组、
+//   手动移动（按频道 ID 存）不顺延。这里按「频道名」配关键字规则，applyConfig 对「未分组」频道
+//   按名字子串匹配（首条命中的规则胜）自动归到对应分组，刷新也不丢。只对未分组生效、不动源已分好的组。
+//   保存即在下次生成播放列表时生效（按文件 mtime 缓存，无需重启）。
+
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { writeJsonFileSync } from './fileUtil.js'
+import { dataPath } from './paths.js'
+
+const RULES_PATH = dataPath('group-keyword-rules.json')
+
+function load() {
+  if (!existsSync(RULES_PATH)) return []
+  try {
+    const o = JSON.parse(readFileSync(RULES_PATH, 'utf-8'))
+    return Array.isArray(o) ? o : []
+  } catch {
+    return []
+  }
+}
+
+function safeMtime(p) {
+  try { return existsSync(p) ? statSync(p).mtimeMs : 0 } catch { return 0 }
+}
+
+let _cache = { sig: null, rules: null }
+
+// 给 applyConfig 用：按 mtime 缓存的规整后规则（每条 {group, keywords[]}，去空）
+export function getKeywordGroupRules() {
+  const sig = String(safeMtime(RULES_PATH))
+  if (_cache.sig === sig && _cache.rules) return _cache.rules
+  const rules = load().map(r => ({
+    group: typeof r?.group === 'string' ? r.group.trim() : '',
+    keywords: Array.isArray(r?.keywords) ? r.keywords.map(k => String(k).trim()).filter(Boolean) : []
+  })).filter(r => r.group && r.keywords.length)
+  _cache = { sig, rules }
+  return rules
+}
+
+// 纯匹配（便于测试 / 复用）：在给定规则集里，频道名按子串包含、大小写不敏感、首条命中胜。
+// 空关键字（""）跳过——否则 includes("") 恒为真会误命中。无命中返回 null。
+export function matchGroupByRules(name, rules) {
+  if (!name || !Array.isArray(rules)) return null
+  const lower = String(name).toLowerCase()
+  for (const r of rules) {
+    const g = r && typeof r.group === 'string' ? r.group : ''
+    const kws = r && Array.isArray(r.keywords) ? r.keywords : []
+    if (g && kws.some(k => { const kk = String(k).toLowerCase(); return kk && lower.includes(kk) })) return g
+  }
+  return null
+}
+
+// 频道名按当前已保存的规则匹配分组（首条命中胜）。无命中返回 null。
+export function matchKeywordGroup(name) {
+  return matchGroupByRules(name, getKeywordGroupRules())
+}
+
+export function getGroupRulesAPI() {
+  try {
+    return { success: true, data: load() }
+  } catch (e) {
+    return { success: false, message: e.message }
+  }
+}
+
+// 新增 / 更新一条规则（按分组名 upsert，原位更新以保持「首条命中胜」的顺序）
+export function setGroupRuleAPI(group, keywords) {
+  try {
+    const g = typeof group === 'string' ? group.trim() : ''
+    if (!g) return { success: false, message: '请填写分组名' }
+    if (g === '未分组') return { success: false, message: '不能把频道自动归到「未分组」' }
+    let list = Array.isArray(keywords) ? keywords : String(keywords || '').split(/[,，\n]/)
+    list = [...new Set(list.map(s => String(s).trim()).filter(Boolean))]
+    if (list.length === 0) return { success: false, message: '请至少填写一个关键字' }
+    const rules = load()
+    const idx = rules.findIndex(r => r && r.group === g)
+    const entry = { group: g, keywords: list }
+    if (idx >= 0) rules[idx] = entry   // 原位更新，保持顺序
+    else rules.push(entry)
+    writeJsonFileSync(RULES_PATH, rules)
+    return { success: true, data: rules }
+  } catch (e) {
+    return { success: false, message: e.message }
+  }
+}
+
+// 删除一条规则
+export function removeGroupRuleAPI(group) {
+  try {
+    const rules = load()
+    const next = rules.filter(r => r && r.group !== group)
+    if (next.length === rules.length) return { success: false, message: '规则不存在' }
+    writeJsonFileSync(RULES_PATH, next)
+    return { success: true, data: next }
+  } catch (e) {
+    return { success: false, message: e.message }
+  }
+}

--- a/utils/playlistConfig.js
+++ b/utils/playlistConfig.js
@@ -5,6 +5,7 @@ import { dataPath } from "./paths.js"
 import { printBlue, printGreen, printYellow, printRed } from "./colorOut.js"
 import { enableTvgNormalize, enableDisplayNameUnify, externalLogoBase } from "../config.js"
 import { getCanonicalMap, normalizeKey, normalizeTvgName, getPlaybackChannelIds } from "./channelNormalize.js"
+import { matchKeywordGroup } from "./groupRulesAPI.js"
 
 // 台标来源分类（供后台展示）：本地上传 / 源自带 / 公共库兜底 / 无。
 // 依据 interface 里写出的 tvg-logo 形态判定，不联网、零额外成本。issue #38 / #40
@@ -335,13 +336,18 @@ export function applyConfig(groups, config) {
         return
       }
 
-      // 目标分组优先级：单频道移动 > 分组重命名 > 原始分组
+      // 目标分组优先级：单频道移动 > 关键字自动分组(仅未分组) > 分组重命名 > 原始分组
       let targetGroup
       if (movedTo) {
         targetGroup = movedTo
       } else {
         targetGroup = channel.originalGroup
-        if (targetGroup !== '未分组' && config.groupRenameMap && config.groupRenameMap[targetGroup]) {
+        if (targetGroup === '未分组') {
+          // 关键字自动分组（issue #69）：只对「未分组」频道按名字子串匹配规则（首条命中胜），
+          // 让自定义源里没写分组、每次刷新又回到未分组的新频道自动归位；不动源已分好的组。
+          const kw = matchKeywordGroup(channel.name)
+          if (kw) targetGroup = kw
+        } else if (config.groupRenameMap && config.groupRenameMap[targetGroup]) {
           targetGroup = config.groupRenameMap[targetGroup]
         }
       }

--- a/web/admin.html
+++ b/web/admin.html
@@ -2134,6 +2134,26 @@
                         <button class="btn btn-sm btn-success" onclick="addAliasRule()">➕ 添加规则</button>
                     </div>
                 </div>
+
+                <!-- 关键字自动分组（issue #69）：按频道名关键字把「未分组」频道自动归类 -->
+                <div style="margin-top: 28px; border-top: 1px solid #eee; padding-top: 20px;">
+                    <div>
+                        <div style="font-size:16px; font-weight:600; color:#333;">🗂️ 关键字自动分组</div>
+                        <div class="system-config-hint">自定义订阅源里没写分组的频道会落到「未分组」，每次刷新又回到未分组。这里按<strong>频道名关键字</strong>配规则，名字含关键字的<strong>未分组</strong>频道会自动归到对应分组（多条规则按从上到下、首条命中生效）——刷新也不丢，且<strong>不影响源已分好的分组、手动移动优先</strong>。如 分组 <code>央视</code> ← 关键字 <code>CCTV, 央视</code>。保存后下次刷新播放列表即生效。</div>
+                    </div>
+                    <div id="groupRuleList" style="margin-top:14px; max-height:320px; overflow-y:auto;"></div>
+                    <div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
+                        <div style="min-width:150px;">
+                            <label style="display:block; font-size:12px; color:#888;">分组名</label>
+                            <input type="text" id="groupRuleName" placeholder="例如 央视" style="width:100%;">
+                        </div>
+                        <div style="flex:1; min-width:200px;">
+                            <label style="display:block; font-size:12px; color:#888;">关键字（多个用逗号分隔，名字含其一即归此组）</label>
+                            <input type="text" id="groupRuleKeywords" placeholder="例如 CCTV, 央视" style="width:100%;">
+                        </div>
+                        <button class="btn btn-sm btn-success" onclick="addGroupRule()">➕ 添加规则</button>
+                    </div>
+                </div>
             </div>
 
             <!-- 关于我们面板 -->
@@ -2278,6 +2298,7 @@
                 loadEpgSources();
                 loadUsers();
                 loadAliases();
+                loadGroupRules();
             }
         }
 
@@ -2581,6 +2602,75 @@
             else showStatus(r.message || '删除失败', 'error');
         }
 
+        // ===== 关键字自动分组（issue #69）=====
+        let groupRulesData = [];
+
+        async function loadGroupRules() {
+            try {
+                const res = await fetch(API_PREFIX + '/api/group-keyword-rules');
+                const p = await res.json();
+                if (p && p.success && Array.isArray(p.data)) { groupRulesData = p.data; renderGroupRules(); }
+            } catch (e) { console.error('加载关键字分组规则失败', e); }
+        }
+
+        function renderGroupRules() {
+            const box = document.getElementById('groupRuleList');
+            if (!box) return;
+            if (!groupRulesData.length) {
+                box.innerHTML = '<div class="system-config-hint" style="margin:0;">还没有规则。添加后，名字含关键字的「未分组」频道会自动归到对应分组（刷新也不丢）。</div>';
+                return;
+            }
+            box.innerHTML = groupRulesData.map(r => {
+                const kws = Array.isArray(r.keywords) ? r.keywords : [];
+                const g = String(r.group || '');
+                const gEsc = g.replace(/'/g, "\\'");
+                return `<div style="border:1px solid #eee;border-radius:6px;padding:10px;margin-bottom:8px;display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;">
+                    <div style="min-width:0;"><strong>${escapeHtml(g)}</strong> <span style="color:#888;font-size:12px;">←</span> <span style="font-size:13px;color:#555;word-break:break-all;">${escapeHtml(kws.join('、'))}</span></div>
+                    <div style="display:flex;gap:6px;flex-shrink:0;">
+                        <button class="btn btn-sm" onclick="editGroupRule('${gEsc}')">编辑</button>
+                        <button class="btn btn-sm btn-danger" onclick="removeGroupRule('${gEsc}')">删除</button>
+                    </div>
+                </div>`;
+            }).join('');
+        }
+
+        async function groupRulesPost(body) {
+            const res = await fetch(API_PREFIX + '/api/group-keyword-rules', {
+                method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
+            });
+            return res.json();
+        }
+
+        async function addGroupRule() {
+            const group = document.getElementById('groupRuleName').value;
+            const keywords = document.getElementById('groupRuleKeywords').value;
+            const r = await groupRulesPost({ action: 'setRule', group, keywords });
+            if (r.success) {
+                groupRulesData = r.data; renderGroupRules();
+                document.getElementById('groupRuleName').value = '';
+                document.getElementById('groupRuleKeywords').value = '';
+                showStatus('已添加规则，下次刷新播放列表生效', 'success');
+            } else showStatus(r.message || '添加失败', 'error');
+        }
+
+        function editGroupRule(group) {
+            const rule = groupRulesData.find(r => r.group === group);
+            if (!rule) return;
+            document.getElementById('groupRuleName').value = rule.group;
+            document.getElementById('groupRuleKeywords').value = (rule.keywords || []).join(', ');
+            document.getElementById('groupRuleName').scrollIntoView({ behavior: 'smooth', block: 'center' });
+            document.getElementById('groupRuleKeywords').focus();
+            showStatus('已载入到下方，可修改后点「添加规则」保存（同名分组会覆盖更新）', 'info');
+        }
+
+        async function removeGroupRule(group) {
+            const confirmed = await showConfirm('确定删除这条分组规则吗？');
+            if (!confirmed) return;
+            const r = await groupRulesPost({ action: 'removeRule', group });
+            if (r.success) { groupRulesData = r.data; renderGroupRules(); showStatus('已删除', 'success'); }
+            else showStatus(r.message || '删除失败', 'error');
+        }
+
         // 在「频道详情」里直接给本频道设别名（issue #62）：把本频道名追加到指定规范名下（不覆盖已有别名），
         // 保存后重新加载「我的频道」即时重算配对状态（别名即时进 getCanonicalMap）。
         async function setAliasFromDetail() {
@@ -2660,6 +2750,7 @@
 
                 // 加载频道别名规则（issue #56）；失败不影响其余加载
                 loadAliases();
+                loadGroupRules();
                 
                 // 加载配置档列表（多套 m3u），再加载当前档的我的频道配置
                 console.log('请求配置档列表...');


### PR DESCRIPTION
## 背景（issue #69）

自定义订阅源里没写分组(group-title)的频道会落到「未分组」，每次更新后新频道又回到未分组，需要每天手动勾选归类。手动「移动到分组」是按频道 ID 存的，源一刷新新频道是新 ID、不顺延，所以重复劳动。

## 方案

新增「关键字自动分组」规则：按**频道名**配关键字（如 `央视 ← CCTV, 央视`），名字含关键字的「未分组」频道在生成播放列表时自动归到对应分组——按名字匹配，刷新也不丢。

- **只对「未分组」生效**：不动源已分好的分组（如源里已是「体育」的 CCTV5 不会被 `CCTV` 规则拽进「央视」）。
- **首条命中胜**：多条规则按从上到下顺序，第一条命中的生效。
- **优先级**：单频道手动移动 > 关键字规则 > 原始分组（手动移动永远赢）。
- **子串包含、大小写不敏感**。

## 改动

- `utils/groupRulesAPI.js`（新增）：规则存储 `data/group-keyword-rules.json`（数组，保序）+ 匹配 + 增删改 API；按文件 mtime 缓存，保存后下次刷新即生效、无需重启。
- `app.js`：`/api/group-keyword-rules` 路由（GET / POST `setRule`|`removeRule`）。
- `utils/playlistConfig.js`：`applyConfig` 目标分组判定的「未分组」分支调用关键字匹配。
- `web/admin.html`：系统配置新增「🗂️ 关键字自动分组」卡片（增删改 + 编辑回填，仿频道别名）。
- `scripts/test-group-keyword.mjs`（新增）：回归测试，已接入 `npm test`。

## 测试

`npm test` 全绿（含本次新增 7/7）。覆盖：纯匹配（子串/大小写/首条命中/空值不误命中）+ applyConfig 不变量（未分组归位、未命中留未分组、源已分组不动、手动移动优先）。

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)