### PR TITLE
feat: #69 跟进 — 添加订阅源时设「默认分组」+ 关键字卡片移出设置垫底

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
-    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs && node scripts/test-move-hide.mjs && node scripts/test-epg-match.mjs && node scripts/test-group-keyword.mjs"
+    "test": "node scripts/test-group-dedup.mjs && node scripts/test-channel-normalize.mjs && node scripts/test-move-hide.mjs && node scripts/test-epg-match.mjs && node scripts/test-group-keyword.mjs && node scripts/test-source-group.mjs"
   },
   "dependencies": {
     "node-fetch": "^3.3.2",

--- a/scripts/test-source-group.mjs
+++ b/scripts/test-source-group.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * 订阅源「默认分组」回退回归测试（issue #69 跟进）
+ *
+ * 不变量（resolveSubscriptionGroup）：
+ *  - 频道自带分组（group-title / #genre#）优先，源默认分组不覆盖它；
+ *  - 频道无分组——空串（txt 无 #genre#）或占位「未分组」（m3u 无 group-title 解析所填）——
+ *    一并视作未分组，回退到源配置的默认分组 source.group；
+ *  - 源也没设默认分组时，仍是「未分组」（向后兼容，零行为变化）。
+ *
+ * 关键点：m3u 解析对无 group-title 的频道填的是字符串「未分组」（不是空串），
+ * 旧的 `ch.group || source.group` 会被它短路，导致默认分组对 m3u 失效——本测试守住修复。
+ *
+ * 运行： node scripts/test-source-group.mjs   （或 npm test）
+ */
+import assert from 'node:assert/strict'
+import { resolveSubscriptionGroup } from '../utils/externalSources.js'
+
+let passed = 0
+const check = (name, fn) => { fn(); passed++; console.log(`  ✅ ${name}`) }
+
+console.log('订阅源默认分组回退回归测试 (issue #69 跟进)')
+
+check('频道自带分组优先：源默认分组不覆盖', () => {
+  assert.equal(resolveSubscriptionGroup({ group: '央视' }, { group: '体育' }), '央视')
+  assert.equal(resolveSubscriptionGroup({ group: '港澳台' }, { group: '未分组' }), '港澳台')
+})
+
+check('m3u 无分组（占位「未分组」）→ 回退源默认分组（修复点）', () => {
+  assert.equal(resolveSubscriptionGroup({ group: '未分组' }, { group: '我的港台' }), '我的港台')
+})
+
+check('txt 无分组（空串）→ 回退源默认分组', () => {
+  assert.equal(resolveSubscriptionGroup({ group: '' }, { group: '我的港台' }), '我的港台')
+  assert.equal(resolveSubscriptionGroup({ group: undefined }, { group: '我的港台' }), '我的港台')
+})
+
+check('源未设默认分组 → 仍「未分组」（向后兼容）', () => {
+  assert.equal(resolveSubscriptionGroup({ group: '未分组' }, { group: '未分组' }), '未分组')
+  assert.equal(resolveSubscriptionGroup({ group: '未分组' }, {}), '未分组')
+  assert.equal(resolveSubscriptionGroup({ group: '' }, { group: '' }), '未分组')
+})
+
+check('边界：缺参数也不抛、回落「未分组」', () => {
+  assert.equal(resolveSubscriptionGroup(null, { group: '体育' }), '体育')
+  assert.equal(resolveSubscriptionGroup({ group: '央视' }, null), '央视')
+  assert.equal(resolveSubscriptionGroup(null, null), '未分组')
+})
+
+console.log(`\n全部通过：${passed}/5 ✅`)

--- a/utils/externalSources.js
+++ b/utils/externalSources.js
@@ -102,6 +102,17 @@ function parsePlaylistContent(content) {
 }
 
 /**
+ * 订阅源频道的最终分组：频道自带分组优先；为空、或仍是占位「未分组」时，
+ * 回退到该源配置的「默认分组」(source.group)。issue #69 跟进——让订阅里没写
+ * group-title 的频道整体归到用户指定的默认分组，而不是堆在「未分组」。
+ * （m3u 解析对无 group-title 的频道填的就是字符串「未分组」，故与空值一并视作未分组。）
+ */
+export function resolveSubscriptionGroup(ch, source) {
+  const own = ch && ch.group && ch.group !== '未分组' ? ch.group : ''
+  return own || (source && source.group) || '未分组'
+}
+
+/**
  * 用 GBK 解码字节，环境无 GBK 解码器时回退宽松 UTF-8
  */
 function decodeGbk(buffer) {
@@ -765,7 +776,7 @@ class ExternalSourceManager {
       // 订阅模式：展开 parsedChannels
       if (source.mode === 'subscription' && Array.isArray(source.parsedChannels)) {
         source.parsedChannels.forEach(ch => {
-          const group = ch.group || source.group || '未分组'
+          const group = resolveSubscriptionGroup(ch, source)
           if (!groupMap.has(group)) {
             groupMap.set(group, {
               name: group,

--- a/web/admin.html
+++ b/web/admin.html
@@ -2041,6 +2041,46 @@
                     💡 提示：保存配置后，需点击页面顶部的"重启服务"按钮使新配置生效
                 </div>
 
+                <!-- 频道别名（issue #56）：自定义批量统一规则 -->
+                <div style="margin-top: 28px; border-top: 1px solid #eee; padding-top: 20px;">
+                    <div>
+                        <div style="font-size:16px; font-weight:600; color:#333;">🔤 频道别名（统一命名规则）</div>
+                        <div class="system-config-hint">给上面的「统一频道显示名」加自定义规则：把若干<strong>别名</strong>都归到一个<strong>规范名</strong>下（如 规范名 <code>CCTV5体育</code>，别名 <code>央视5套, 体育频道</code>）。内置规则（CCTV 系列、清晰度后缀等）已覆盖大部分，这里只补兜不住的写法。保存后下次刷新播放列表即生效。</div>
+                    </div>
+                    <div id="aliasList" style="margin-top:14px; max-height:320px; overflow-y:auto;"></div>
+                    <div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
+                        <div style="min-width:150px;">
+                            <label style="display:block; font-size:12px; color:#888;">规范名（统一后的名字）</label>
+                            <input type="text" id="aliasNewCanonical" placeholder="例如 CCTV5体育" style="width:100%;">
+                        </div>
+                        <div style="flex:1; min-width:200px;">
+                            <label style="display:block; font-size:12px; color:#888;">别名（多个用逗号分隔）</label>
+                            <input type="text" id="aliasNewList" placeholder="例如 央视5套, 体育频道" style="width:100%;">
+                        </div>
+                        <button class="btn btn-sm btn-success" onclick="addAliasRule()">➕ 添加规则</button>
+                    </div>
+                </div>
+
+                <!-- 关键字自动分组（issue #69）：按频道名关键字把「未分组」频道自动归类 -->
+                <div style="margin-top: 28px; border-top: 1px solid #eee; padding-top: 20px;">
+                    <div>
+                        <div style="font-size:16px; font-weight:600; color:#333;">🗂️ 关键字自动分组</div>
+                        <div class="system-config-hint">自定义订阅源里没写分组的频道会落到「未分组」，每次刷新又回到未分组。这里按<strong>频道名关键字</strong>配规则，名字含关键字的<strong>未分组</strong>频道会自动归到对应分组（多条规则按从上到下、首条命中生效）——刷新也不丢，且<strong>不影响源已分好的分组、手动移动优先</strong>。如 分组 <code>央视</code> ← 关键字 <code>CCTV, 央视</code>。保存后下次刷新播放列表即生效。</div>
+                    </div>
+                    <div id="groupRuleList" style="margin-top:14px; max-height:320px; overflow-y:auto;"></div>
+                    <div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
+                        <div style="min-width:150px;">
+                            <label style="display:block; font-size:12px; color:#888;">分组名</label>
+                            <input type="text" id="groupRuleName" placeholder="例如 央视" style="width:100%;">
+                        </div>
+                        <div style="flex:1; min-width:200px;">
+                            <label style="display:block; font-size:12px; color:#888;">关键字（多个用逗号分隔，名字含其一即归此组）</label>
+                            <input type="text" id="groupRuleKeywords" placeholder="例如 CCTV, 央视" style="width:100%;">
+                        </div>
+                        <button class="btn btn-sm btn-success" onclick="addGroupRule()">➕ 添加规则</button>
+                    </div>
+                </div>
+
                 <!-- EPG 节目单聚合（issue #38）：独立保存，无需重启 -->
                 <div style="margin-top: 28px; border-top: 1px solid #eee; padding-top: 20px;">
                     <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px;">
@@ -2115,45 +2155,6 @@
                     </div>
                 </div>
 
-                <!-- 频道别名（issue #56）：自定义批量统一规则 -->
-                <div style="margin-top: 28px; border-top: 1px solid #eee; padding-top: 20px;">
-                    <div>
-                        <div style="font-size:16px; font-weight:600; color:#333;">🔤 频道别名（统一命名规则）</div>
-                        <div class="system-config-hint">给上面的「统一频道显示名」加自定义规则：把若干<strong>别名</strong>都归到一个<strong>规范名</strong>下（如 规范名 <code>CCTV5体育</code>，别名 <code>央视5套, 体育频道</code>）。内置规则（CCTV 系列、清晰度后缀等）已覆盖大部分，这里只补兜不住的写法。保存后下次刷新播放列表即生效。</div>
-                    </div>
-                    <div id="aliasList" style="margin-top:14px; max-height:320px; overflow-y:auto;"></div>
-                    <div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
-                        <div style="min-width:150px;">
-                            <label style="display:block; font-size:12px; color:#888;">规范名（统一后的名字）</label>
-                            <input type="text" id="aliasNewCanonical" placeholder="例如 CCTV5体育" style="width:100%;">
-                        </div>
-                        <div style="flex:1; min-width:200px;">
-                            <label style="display:block; font-size:12px; color:#888;">别名（多个用逗号分隔）</label>
-                            <input type="text" id="aliasNewList" placeholder="例如 央视5套, 体育频道" style="width:100%;">
-                        </div>
-                        <button class="btn btn-sm btn-success" onclick="addAliasRule()">➕ 添加规则</button>
-                    </div>
-                </div>
-
-                <!-- 关键字自动分组（issue #69）：按频道名关键字把「未分组」频道自动归类 -->
-                <div style="margin-top: 28px; border-top: 1px solid #eee; padding-top: 20px;">
-                    <div>
-                        <div style="font-size:16px; font-weight:600; color:#333;">🗂️ 关键字自动分组</div>
-                        <div class="system-config-hint">自定义订阅源里没写分组的频道会落到「未分组」，每次刷新又回到未分组。这里按<strong>频道名关键字</strong>配规则，名字含关键字的<strong>未分组</strong>频道会自动归到对应分组（多条规则按从上到下、首条命中生效）——刷新也不丢，且<strong>不影响源已分好的分组、手动移动优先</strong>。如 分组 <code>央视</code> ← 关键字 <code>CCTV, 央视</code>。保存后下次刷新播放列表即生效。</div>
-                    </div>
-                    <div id="groupRuleList" style="margin-top:14px; max-height:320px; overflow-y:auto;"></div>
-                    <div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap; align-items:flex-end;">
-                        <div style="min-width:150px;">
-                            <label style="display:block; font-size:12px; color:#888;">分组名</label>
-                            <input type="text" id="groupRuleName" placeholder="例如 央视" style="width:100%;">
-                        </div>
-                        <div style="flex:1; min-width:200px;">
-                            <label style="display:block; font-size:12px; color:#888;">关键字（多个用逗号分隔，名字含其一即归此组）</label>
-                            <input type="text" id="groupRuleKeywords" placeholder="例如 CCTV, 央视" style="width:100%;">
-                        </div>
-                        <button class="btn btn-sm btn-success" onclick="addGroupRule()">➕ 添加规则</button>
-                    </div>
-                </div>
             </div>
 
             <!-- 关于我们面板 -->
@@ -3163,6 +3164,11 @@
                             <div class="form-hint">选择文件或粘贴内容后，点下方「📥 导入并保存」即可解析入库；本地导入不发起网络请求</div>
                             `}
                             ${channelInfo}
+                        </div>
+                        <div class="external-field">
+                            <label>默认分组</label>
+                            ${renderGroupSelect(index, source.group || '未分组')}
+                            <div class="form-hint">订阅里<strong>没自带分组</strong>的频道统一归到这个分组（频道自带分组的保持不变）。保持「未分组」则不归类，可在「🗂️ 关键字自动分组」里按频道名细分。</div>
                         </div>
                         <div class="external-field">
                             <label>自动刷新间隔（分钟）</label>


### PR DESCRIPTION
issue #69 的跟进讨论（维护者选了**方案 A**）：把分组前移到「添加订阅源」的环节，而不是只靠埋在系统配置最底的全局关键字卡片。

## 改动

**1. 订阅源表单新增「默认分组」下拉**
- 订阅里**没自带分组**（m3u 无 `group-title` / txt 无 `#genre#`）的频道，整体归到这个默认分组；**频道自带分组的保持不变**。
- 复用源记录里**早已存在**的 `group` 字段（直连/抓取模式本就有分组下拉，订阅模式此前缺这个口子）。

**2. 后端 `resolveSubscriptionGroup`（externalSources.js）**
- 关键修复：`parseM3uContent` 对无 `group-title` 的频道填的是占位字符串 `'未分组'`（非空串），旧的 `ch.group || source.group` 会被它**短路**，导致默认分组对 m3u **失效**。
- 新函数把占位 `'未分组'` 与空串**一并视作未分组**，再回退到 `source.group`。txt 的空串分组同样受益。
- `getValidChannels` 改用它（解析阶段就 bake 进分组，早于合并，不受「合并后丢源信息」影响）。

**3. 与全局「关键字自动分组」天然互补、不打架**
- 设了默认分组的频道不再是「未分组」→ 关键字规则自动跳过；
- 没设默认分组的 → 仍由关键字规则按名字兜底细分。

**4. 卡片不再垫底**
- 把「🔤 频道别名」「🗂️ 关键字自动分组」两张规则卡片从系统配置**最底**（用户管理之下）上移到核心设置之后、EPG 之前，与「统一显示名」命名设置聚在一起。

## 验证
- `npm test` 全绿（8 组，含新增 `test-source-group.mjs` 5/5）。
- admin.html：`<script>` vm 语法通过；`<div>` 开合 295/295 守恒；`#aliasList`/`#groupRuleList` 各唯一；卡片顺序 `统一显示名 < 别名 < 关键字 < EPG < 关于我们`；新旧接缝逐处人工核对。

Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)