### PR TITLE
chore: 清理 IPTV.m3u 失效频道（探活剔除 23 个确认 404 死链）

### DIFF
--- a/IPTV.m3u
+++ b/IPTV.m3u
@@ -10,44 +10,22 @@ https://live-auth.51kandianshi.com/szgd/csztv4.m3u8
 http://hls.nntv.cn/nnlive/YSYL_244.m3u8
 #EXTINF:-1 group-title="综艺",云南娱乐
 https://hwapi.yntv.net/62hdvf/q9vs1b.m3u8
-#EXTINF:-1 group-title="综艺",澳门综艺
-http://cdn6.163189.xyz/163189/amzy
 #EXTINF:-1 group-title="综艺",梨园频道
 https://dxtx.hntv.tv/live/lypd.m3u8?txSecret=10c771842a0be59e8b575d765173ec96&txTime=7B923E0A&wsSecret=1966aa8a0405e1541cff782f56c75447&wsTime=1770400669
 #EXTINF:-1 group-title="综艺",河南曲艺
 https://dxtx.hntv.tv/live/jczy.m3u8?txSecret=e785008e49564e5e738439b4dd2ae68e&txTime=7C4C6207&wsSecret=3f9e1d6e5c78cea99a876ce40f13202b&wsTime=1770400669
 
-
-#EXTINF:-1 group-title="体育",澳门体育
-http://cdn6.163189.xyz/163189/amty
 #EXTINF:-1 group-title="体育",Red Bull TV
 http://rbmn-live.akamaized.net/hls/live/590964/BoRB-AT/master_3360.m3u8
 
-
-#EXTINF:-1 group-title="亚太",凤凰中文
-http://cdn6.163189.xyz/163189/fhzw
-#EXTINF:-1 group-title="亚太",凤凰资讯
-http://cdn6.163189.xyz/163189/fhzx
-#EXTINF:-1 group-title="亚太",凤凰香港
-http://cdn6.163189.xyz/163189/fhhk
 #EXTINF:-1 group-title="亚太",Astro AOD
 https://o11.163189.xyz/stream/live/aod/
 #EXTINF:-1 group-title="亚太",Astro AEC
 https://o11.163189.xyz/stream/live/aec/
-#EXTINF:-1 group-title="亚太",无线新闻
-http://cdn6.163189.xyz/163189/wxxw
 #EXTINF:-1 group-title="亚太",TVBS亚洲
 http://38.64.72.148/hls/modn/list/4005/playlist.m3u8
 #EXTINF:-1 group-title="亚太",TVBS亚洲
 http://38.64.72.148/hls/modn/list/4005/chunklist1.m3u8
-#EXTINF:-1 group-title="亚太",NOW新闻
-http://cdn.163189.xyz/163189/now
-#EXTINF:-1 group-title="亚太",CH5
-http://cdn6.163189.xyz/163189/ch5
-#EXTINF:-1 group-title="亚太",CH8
-http://cdn6.163189.xyz/163189/ch8
-#EXTINF:-1 group-title="亚太",CHU
-http://cdn6.163189.xyz/163189/chu
 #EXTINF:-1 group-title="亚太",翡翠台
 https://o11.163189.xyz/stream/tvb/fct/
 #EXTINF:-1 group-title="亚太",明珠台
@@ -64,22 +42,8 @@ rtmp://f13h.mine.nu/sat/tv701
 rtmp://f13h.mine.nu/sat/tv771
 #EXTINF:-1 group-title="亚太",东森超视
 rtmp://f13h.mine.nu/sat/tv331
-#EXTINF:-1 group-title="亚太",八度空间
-http://cdn6.163189.xyz/163189/8tv
-#EXTINF:-1 group-title="亚太",澳视澳门
-http://cdn6.163189.xyz/163189/asam
-#EXTINF:-1 group-title="亚太",澳门莲花
-http://cdn6.163189.xyz/163189/amlh
 #EXTINF:-1 group-title="亚太",TVB Plus
 https://o11.163189.xyz/stream/tvb/tvbp/
-#EXTINF:-1 group-title="亚太",HOY77
-http://cdn6.163189.xyz/163189/hoy
-#EXTINF:-1 group-title="亚太",HOY78
-http://cdn.163189.xyz/163189/hoy78
-#EXTINF:-1 group-title="亚太",RTHK 32
-http://cdn.163189.xyz/163189/rthk32
-#EXTINF:-1 group-title="亚太",ViuTV
-https://cdn.163189.xyz/163189/viu
 #EXTINF:-1 tvg-id="456560" tvg-name="非凡新聞HD" tvg-logo="https://epg.pw/media/images/channel/2016/06/17/large/20160617165249161501_56.png" group-title="亚太",非凡新聞
 rtmp://f13h.mine.nu/sat/tv581
 #EXTINF:-1 group-title="亚太",耀才财经
@@ -99,10 +63,6 @@ http://cdn8.163189.xyz/163189/lhxj
 https://cdn8.163189.xyz/163189/lhdy
 #EXTINF:-1 group-title="影视",龙华经典
 https://cdn8.163189.xyz/163189/lhjd
-#EXTINF:-1 group-title="影视",重温经典
-http://cdn6.163189.xyz/163189/cwjd
-#EXTINF:-1 group-title="影视",TVB武侠
-http://cdn6.163189.xyz/163189/yzwx
 #EXTINF:-1 group-title="影视",TVB星河
 https://o11.163189.xyz/stream/live/tvbxh/
 #EXTINF:-1 group-title="影视",千禧经典
@@ -111,14 +71,6 @@ https://o11.163189.xyz/stream/live/tvbc/
 https://o11.163189.xyz/stream/live/typd/
 #EXTINF:-1 group-title="影视",ASTRO爱奇艺
 https://o11.163189.xyz/stream/live/iqiyi/
-#EXTINF:-1 group-title="影视",邵氏动作
-http://feilong123.vip/409990236/tv.php?id=ssdz
-#EXTINF:-1 group-title="影视",邵氏电影
-http://feilong123.vip/409990236/tv.php?id=ssdy
-#EXTINF:-1 group-title="影视",邵氏武侠
-http://feilong123.vip/409990236/tv.php?id=sswx
-#EXTINF:-1 group-title="影视",邵氏喜剧
-http://feilong123.vip/409990236/tv.php?id=ssxj
 
 #EXTINF:-1 group-title="纪实",文物宝库
 https://dxtx.hntv.tv/live/wwbk.m3u8?txSecret=317b89626134fd6bea6e129455b5ff18&txTime=7C4C635C&wsSecret=87c5daf4f4c3a09fb4e4cce0843d4a1c&wsTime=1770400669


### PR DESCRIPTION
用 `scripts/probe-m3u.mjs` 对内置「精选频道」`IPTV.m3u` 探活后，剔除**确认 404** 的死链。

## 删除（23 个，服务器实回 HTTP 404 = 路径已不存在、与探测网络无关）
澳门综艺 / 澳门体育、凤凰中文 / 资讯 / 香港、无线新闻、NOW新闻、CH5 / CH8 / CHU、八度空间、澳视澳门、澳门莲花、HOY77 / HOY78、RTHK 32、ViuTV、重温经典、TVB武侠、邵氏动作 / 电影 / 武侠 / 喜剧。

**94 → 71 个频道**（`-48` 行：23×2 成对 + 2 处折叠空行；结构 0 异常）。

## 刻意保留、未删的 15 个存疑项
本次探活在 CI/沙箱网络，**不代表用户真实网络**，实锤了两个假死信号，故一律保留：
- **苏州4K**（cert 过期）：`curl -k` 忽略证书探测实为 **HTTP 200**，播放器普遍可播 → 其实是活的；
- **o11.163189.xyz ×9**（翡翠台 / 明珠台 / TVB Plus / Astro 系列等）：被本机 DNS **劫持到 `198.18.x.x` 保留段**，属假死；
- **cdn8.163189.xyz ×5**（龙华偶像/日韩/戏剧/电影/经典）：403，带 Referer 仍 403，疑地域/鉴权，从本网络无法判定。

> 建议在**真实部署网络**上跑 `DRY_RUN=0 node scripts/probe-m3u.mjs` 复核这 14 个（苏州4K 已确认可用无需再验），确属死链再删。

## 生效方式
`IPTV.m3u` 为远程下发，合并到 `main` 后经 GitHub raw + 镜像对所有部署即时生效，**无需重建镜像 / 发版**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)