### PR TITLE
docs: 澄清画质提示——游客最高 540p、填免费咪咕账号可到 720p（issue #76）

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -1944,12 +1944,12 @@
                     <div class="system-config-item">
                         <label>咪咕用户ID</label>
                         <input type="text" id="sysUserId" placeholder="留空为游客模式">
-                        <div class="system-config-hint">VIP用户填写，游客模式可留空</div>
+                        <div class="system-config-hint">填咪咕账号可解锁更高画质：免费账号即到 720p；游客不填最高 540p，1080p+ 需 VIP</div>
                     </div>
                     <div class="system-config-item">
                         <label>咪咕Token</label>
                         <input type="text" id="sysToken" placeholder="留空为游客模式">
-                        <div class="system-config-hint">VIP用户填写，游客模式可留空</div>
+                        <div class="system-config-hint">填咪咕账号可解锁更高画质：免费账号即到 720p；游客不填最高 540p，1080p+ 需 VIP</div>
                     </div>
                     <div class="system-config-item">
                         <label>画质</label>
@@ -1960,7 +1960,7 @@
                             <option value="7">原画 (1080p+ · 需VIP)</option>
                             <option value="9">4K (2160p · 需VIP)</option>
                         </select>
-                        <div class="system-config-hint">720p及以下免费，更高画质需要VIP</div>
+                        <div class="system-config-hint">实际画质受咪咕账号档位限制：游客（不填账号）最高 540p；填免费咪咕账号可到 720p；蓝光 1080p / 原画 / 4K 需 VIP</div>
                     </div>
                     <div class="system-config-item">
                         <label>服务端口</label>


### PR DESCRIPTION
issue #76：ponyspeed 反馈「访客模式清晰度最高只有 540p」。经排查**不是 bug**，是咪咕对「游客(tourist)」的服务端限档——游客即便请求 720p(rateType=3)，咪咕也只回 540P（有人抓过返回体 `urlType:tourist` / `rateDesc:标清 540P`）。填账号走「带账号请求」才有 720p（免费账号即可，1080p 蓝光需 VIP）。

问题根源之一是 UI 提示误导，让用户以为游客也能 720p。本 PR 只改文案：

- 咪咕 ID / Token 提示：`VIP用户填写，游客模式可留空` → `填咪咕账号可解锁更高画质：免费账号即到 720p；游客不填最高 540p，1080p+ 需 VIP`
- 画质提示：`720p及以下免费，更高画质需要VIP` → `实际画质受咪咕账号档位限制：游客（不填账号）最高 540p；填免费咪咕账号可到 720p；蓝光 1080p / 原画 / 4K 需 VIP`

纯文案改动（3 行），脚本语法通过。随下个版本镜像生效。

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)