### PR TITLE
docs: Node 版本要求改为 20+；修 Dockerfile 里失效的跳过下载变量

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /migu
 COPY package*.json ./
 
 # 跳过 Puppeteer 自动下载 Chromium，使用系统的（更快更稳定）
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+# 注意变量名是 PUPPETEER_SKIP_DOWNLOAD，不是 ..._SKIP_CHROMIUM_DOWNLOAD（后者 puppeteer 不认，是空操作）
+ENV PUPPETEER_SKIP_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # 使用 npm ci 替代 npm install，速度更快且更可靠

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ A：这类播放器**不跟随 302 跳转**。改用**兼容版订阅**：后台
 
 ### 🔧 本地运行（不用 Docker）
 
-需要 Node.js 18+；部分平台的频道需要中国大陆网络环境。
+需要 Node.js 20+（推荐 22 LTS）；部分平台的频道需要中国大陆网络环境。
 
 ```bash
 git clone https://github.com/akiralereal/iptv.git && cd iptv


### PR DESCRIPTION
两处独立的小修，**均不改变现有行为**，各一行。

## 1. Dockerfile：`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` → `PUPPETEER_SKIP_DOWNLOAD`

前者 puppeteer 根本不认——它的浏览器键是 `chrome`，没有 `chromium`，所以只认 `PUPPETEER_SKIP_DOWNLOAD` / `PUPPETEER_SKIP_CHROME_DOWNLOAD`。这行一直是空操作。

实测 puppeteer 24.37.3 下 `getConfiguration().skipDownload`：

| 环境变量 | 解析结果 |
|---|---|
| 什么都不设 | `undefined` |
| `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` | `undefined` ← 旧写法，**无效** |
| `PUPPETEER_SKIP_DOWNLOAD=true` | `true` ← 新写法 |

之所以至今没出问题，是同一行的 `PUPPETEER_EXECUTABLE_PATH` 会隐式把 `skipDownload` 置真。也就是说这行一直靠邻居兜着；哪天 `executablePath` 被去掉，镜像就会悄悄多下一个 Chrome。

## 2. README：「需要 Node.js 18+」→「需要 Node.js 20+（推荐 22 LTS）」

| 版本 | 安全支持结束 |
|---|---|
| Node 18 | 2025-04-30（已断供 16 个月） |
| Node 20 | 2026-04-30 |
| **Node 22** | 2027-04-30 ✅ |

继续推荐 18 等于推荐一个断供一年多的运行时。代码本身只用到 `fetch`，在 18 上仍能跑，这里只是把**建议**底线抬到仍在维护的版本，不是加硬性门槛（未加 `engines` 字段）。

## 验证

- `npm test` 16/16 通过，退出码 0
- Dockerfile 变量名改动已在 puppeteer 24.37.3 上实测（见上表）

🤖 Generated with [Claude Code](https://claude.com/claude-code)